### PR TITLE
Add pytest suite for parser and runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,13 @@ int32 sat_add(int32 a, int32 b)
 ---
 
 For information on the compiler internals and verification agents, see [AGENTS.md](AGENTS.md).
+
+## Running Tests
+
+Install pytest and execute the suite:
+
+```bash
+python -m pip install pytest
+pytest
+```
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,33 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from pathlib import Path
+from safelang import parse_functions
+
+
+def test_parse_example():
+    text = Path("example.slang").read_text()
+    funcs = parse_functions(text)
+    assert len(funcs) == 2
+
+    init_fn = funcs[0]
+    assert init_fn.name == "clamp_params_init"
+    assert init_fn.space == "512B"
+    assert init_fn.time == "10_000ns"
+    assert init_fn.consume == ["nil"]
+    assert init_fn.emit == ["nil"]
+
+    clamp_fn = funcs[1]
+    assert clamp_fn.name == "clamp_params"
+    assert clamp_fn.space == "128B"
+    assert clamp_fn.time == "1000ns"
+    assert clamp_fn.consume == [
+        "f32(x) # [0, 3/2]       ! 0 \u2264 x \u2264 1.5",
+        "f32(y) # [-3, 4.29382)  ! -3 \u2264 y < 4.29382",
+        "f32(z) # [-inf, pi]     ! -\u221e \u2264 z \u2264 \u03c0",
+    ]
+    assert clamp_fn.emit == [
+        "f32(cl_x) # [0, 1]",
+        "f32(cl_y) # [-3, 3]",
+        "f32(cl_z) # [-1.1, 2]",
+    ]

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,46 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import safelang.runtime as rt
+
+
+def test_sat_add_normal():
+    value, saturated = rt.sat_add(10, 20, 8, signed=True)
+    assert value == 30
+    assert not saturated
+
+
+def test_sat_add_saturates_max():
+    value, saturated = rt.sat_add(120, 20, 8, signed=True)
+    assert value == 127
+    assert saturated
+
+
+def test_sat_sub_normal():
+    value, saturated = rt.sat_sub(20, 10, 8, signed=True)
+    assert value == 10
+    assert not saturated
+
+
+def test_sat_sub_saturates_min():
+    value, saturated = rt.sat_sub(-120, 20, 8, signed=True)
+    assert value == -128
+    assert saturated
+
+
+def test_sat_mul_normal():
+    value, saturated = rt.sat_mul(5, 4, 8, signed=True)
+    assert value == 20
+    assert not saturated
+
+
+def test_sat_mul_saturates_max():
+    value, saturated = rt.sat_mul(20, 20, 8, signed=True)
+    assert value == 127
+    assert saturated
+
+
+def test_sat_mul_saturates_min():
+    value, saturated = rt.sat_mul(-20, 20, 8, signed=True)
+    assert value == -128
+    assert saturated


### PR DESCRIPTION
## Summary
- add parser and runtime unit tests
- document running the tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685300d514ac8328a8cad198e86de7c0