### PR TITLE
Handle saturating overflow via exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ function "adjust_thrust" {
 
 * All arithmetic operations are saturating by default
 * Arithmetic is performed using a **widened type**, then clamped to the original type's bounds
+* The Python demo runtime raises ``SaturatingOverflow`` if a value would need to
+  be clamped
 
 ```c
 int32 sat_add(int32 a, int32 b)
@@ -95,7 +97,7 @@ int32 sat_add(int32 a, int32 b)
 ## Runtime Behavior
 
 * Saturating arithmetic is deterministic and portable
-* Overflow never wraps
+* Overflow never wraps and triggers a ``SaturatingOverflow`` exception
 * All failures (e.g., time/space overrun, assertion fail) result in predictable halt or fallback
 
 ---

--- a/SPEC.md
+++ b/SPEC.md
@@ -32,6 +32,7 @@ This document outlines the formal specification of SafeLang's type system, synta
 | `float64` | 64-bit float    | IEEE-754           |
 
 All arithmetic on integer types is **saturating** and implemented via **upcast + clamp**.
+If clamping would occur at runtime, a ``SaturatingOverflow`` exception is raised.
 
 ### Compound Types
 

--- a/demo.py
+++ b/demo.py
@@ -1,6 +1,11 @@
 """Demonstration of the SafeLang parser and saturating math."""
 
-from safelang import parse_functions, verify_contracts, sat_add
+from safelang import (
+    parse_functions,
+    verify_contracts,
+    sat_add,
+    SaturatingOverflow,
+)
 
 
 def main() -> None:
@@ -19,8 +24,11 @@ def main() -> None:
     else:
         print("No contract errors found")
 
-    value, saturated = sat_add(2147483640, 100, 32, signed=True)
-    print(f"sat_add result={value} saturated={saturated}")
+    try:
+        value = sat_add(2147483640, 100, 32, signed=True)
+        print(f"sat_add result={value}")
+    except SaturatingOverflow as exc:
+        print(f"Overflow occurred: {exc}")
 
 
 if __name__ == "__main__":

--- a/safelang/__init__.py
+++ b/safelang/__init__.py
@@ -1,12 +1,13 @@
 """Minimal demo runtime for the SafeLang compiler."""
 
-from .runtime import sat_add, sat_sub, sat_mul
+from .runtime import SaturatingOverflow, sat_add, sat_sub, sat_mul
 from .parser import FunctionDef, parse_functions, verify_contracts
 
 __all__ = [
     "sat_add",
     "sat_sub",
     "sat_mul",
+    "SaturatingOverflow",
     "FunctionDef",
     "parse_functions",
     "verify_contracts",

--- a/safelang/runtime.py
+++ b/safelang/runtime.py
@@ -1,11 +1,15 @@
 """SafeLang runtime helpers for saturating arithmetic.
+
+If a value exceeds the representable range during clamping, a
+``SaturatingOverflow`` error is raised. Callers are expected to catch this
+exception to handle overflow conditions explicitly.
 """
 
 from typing import Tuple
 
 
 class SaturatingOverflow(Exception):
-    """Raised when saturation occurs."""
+    """Raised when a value would exceed the representable range."""
 
 
 def bounds(bits: int, signed: bool) -> Tuple[int, int]:
@@ -18,30 +22,30 @@ def bounds(bits: int, signed: bool) -> Tuple[int, int]:
     return min_val, max_val
 
 
-def clamp(value: int, bits: int, signed: bool) -> Tuple[int, bool]:
-    """Clamp value to the representable range.
+def clamp(value: int, bits: int, signed: bool) -> int:
+    """Clamp ``value`` to the representable range.
 
-    Returns the clamped value and whether it saturated.
+    Raises ``SaturatingOverflow`` if the value is outside the range.
     """
     min_val, max_val = bounds(bits, signed)
-    if value > max_val:
-        return max_val, True
-    if value < min_val:
-        return min_val, True
-    return value, False
+    if value > max_val or value < min_val:
+        raise SaturatingOverflow(
+            f"value {value} outside [{min_val}, {max_val}]"
+        )
+    return value
 
 
-def sat_add(a: int, b: int, bits: int, signed: bool = True) -> Tuple[int, bool]:
+def sat_add(a: int, b: int, bits: int, signed: bool = True) -> int:
     total = int(a) + int(b)
     return clamp(total, bits, signed)
 
 
-def sat_sub(a: int, b: int, bits: int, signed: bool = True) -> Tuple[int, bool]:
+def sat_sub(a: int, b: int, bits: int, signed: bool = True) -> int:
     total = int(a) - int(b)
     return clamp(total, bits, signed)
 
 
-def sat_mul(a: int, b: int, bits: int, signed: bool = True) -> Tuple[int, bool]:
+def sat_mul(a: int, b: int, bits: int, signed: bool = True) -> int:
     total = int(a) * int(b)
     return clamp(total, bits, signed)
 


### PR DESCRIPTION
## Summary
- signal saturating overflow using `SaturatingOverflow`
- export the new exception at the package level
- update demo to catch the overflow
- document overflow behaviour
- mention overflow exception in the specification

## Testing
- `python demo.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685300d15a6c83288ec614f577927d2e