### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run tests
+        run: pytest -v


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow to run pytest on pushes and PRs

## Testing
- `pytest -q` *(fails: cannot unpack non-iterable int object)*

------
https://chatgpt.com/codex/tasks/task_e_6853020380d083288c94f076d2689334