### PR TITLE
Add CLI subprocess tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cli_valid():
+    file = Path('example.slang')
+    result = subprocess.run([sys.executable, '-m', 'safelang', str(file)], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert 'Parsed' in result.stdout
+
+
+def test_cli_invalid(tmp_path):
+    invalid_src = (
+        'function "foo" {\n'
+        '    @space 128B\n'
+        '    consume { nil }\n'
+        '    emit { nil }\n'
+        '}\n'
+    )
+    invalid_file = tmp_path / 'invalid.slang'
+    invalid_file.write_text(invalid_src)
+    result = subprocess.run([sys.executable, '-m', 'safelang', str(invalid_file)], capture_output=True, text=True)
+    assert result.returncode != 0
+    assert 'ERROR' in result.stdout


### PR DESCRIPTION
## Summary
- test `python -m safelang` on a valid file
- test that missing contract info triggers CLI failure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530ac001548328b1378628d96f4f4e