### PR TITLE
Add contract verification tests

### DIFF
--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from safelang.parser import parse_functions, verify_contracts
+
+
+def _verify(src: str):
+    funcs = parse_functions(src)
+    return verify_contracts(funcs)
+
+
+def test_missing_space():
+    src = 'function "foo" {\n@time 1ns\nconsume { nil }\nemit { nil }\n}'
+    errors = _verify(src)
+    assert errors == ["Function foo missing @space"]
+
+
+def test_missing_time():
+    src = 'function "bar" {\n@space 1B\nconsume { nil }\nemit { nil }\n}'
+    errors = _verify(src)
+    assert errors == ["Function bar missing @time"]
+
+
+def test_missing_consume():
+    src = 'function "baz" {\n@space 1B\n@time 1ns\nemit { nil }\n}'
+    errors = _verify(src)
+    assert errors == ["Function baz missing consume block"]
+
+
+def test_missing_emit():
+    src = 'function "qux" {\n@space 1B\n@time 1ns\nconsume { nil }\n}'
+    errors = _verify(src)
+    assert errors == ["Function qux missing emit block"]
+
+
+def test_all_contracts_present():
+    src = 'function "ok" {\n@space 1B\n@time 1ns\nconsume { nil }\nemit { nil }\n}'
+    errors = _verify(src)
+    assert errors == []


### PR DESCRIPTION
## Summary
- test `verify_contracts` for missing `@space`, `@time`, `consume`, and `emit`
- add passing case with all contracts present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530abe176883289a6ce6825a0df5d1