### PR TITLE
Remove unused SaturatingOverflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ function "adjust_thrust" {
 * All arithmetic operations are saturating by default
 * Arithmetic is performed using a **widened type**, then clamped to the original type's bounds
 * The Python demo runtime returns the clamped value along with a boolean flag
-  indicating whether saturation occurred
+  indicating whether saturation occurred. No exception is raised on overflow.
 
 ```c
 int32 sat_add(int32 a, int32 b)

--- a/safelang/__init__.py
+++ b/safelang/__init__.py
@@ -1,13 +1,12 @@
 """Minimal demo runtime for the SafeLang compiler."""
 
-from .runtime import SaturatingOverflow, sat_add, sat_sub, sat_mul
+from .runtime import sat_add, sat_sub, sat_mul
 from .parser import FunctionDef, parse_functions, verify_contracts
 
 __all__ = [
     "sat_add",
     "sat_sub",
     "sat_mul",
-    "SaturatingOverflow",
     "FunctionDef",
     "parse_functions",
     "verify_contracts",

--- a/safelang/runtime.py
+++ b/safelang/runtime.py
@@ -1,17 +1,11 @@
 """SafeLang runtime helpers for saturating arithmetic.
 
 All helpers return both the clamped result and a boolean indicating whether
-the operation saturated. Earlier revisions raised ``SaturatingOverflow`` when
-overflow occurred but the test-suite expects a non‑throwing API.  The
-exception class is kept for backwards compatibility but is no longer used by
-these helpers.
+the operation saturated. Overflow never raises an exception; callers must
+check the returned flag to determine if clamping occurred.
 """
 
 from typing import Tuple
-
-
-class SaturatingOverflow(Exception):
-    """Raised when a value would exceed the representable range."""
 
 
 def bounds(bits: int, signed: bool) -> Tuple[int, int]:
@@ -57,7 +51,6 @@ def sat_mul(a: int, b: int, bits: int, signed: bool = True) -> Tuple[int, bool]:
 
 
 __all__ = [
-    "SaturatingOverflow",
     "bounds",
     "clamp",
     "sat_add",

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -44,3 +44,7 @@ def test_sat_mul_saturates_min():
     value, saturated = rt.sat_mul(-20, 20, 8, signed=True)
     assert value == -128
     assert saturated
+
+
+def test_no_saturating_overflow_export():
+    assert not hasattr(rt, "SaturatingOverflow")


### PR DESCRIPTION
## Summary
- drop the unused `SaturatingOverflow` exception
- clarify saturating arithmetic docs
- export only runtime helpers
- verify that `SaturatingOverflow` is no longer available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530ac2a7bc8328bfdc2682a382f56a