### PR TITLE
Add unsigned arithmetic tests

### DIFF
--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -43,5 +43,47 @@ def test_sat_mul_saturates_min():
     assert saturated
 
 
+def test_sat_add_unsigned_normal():
+    value, saturated = rt.sat_add(10, 20, 8, signed=False)
+    assert value == 30
+    assert not saturated
+
+
+def test_sat_add_unsigned_saturates_max():
+    value, saturated = rt.sat_add(250, 20, 8, signed=False)
+    assert value == 255
+    assert saturated
+
+
+def test_sat_sub_unsigned_normal():
+    value, saturated = rt.sat_sub(20, 10, 8, signed=False)
+    assert value == 10
+    assert not saturated
+
+
+def test_sat_sub_unsigned_saturates_min():
+    value, saturated = rt.sat_sub(10, 20, 8, signed=False)
+    assert value == 0
+    assert saturated
+
+
+def test_sat_mul_unsigned_normal():
+    value, saturated = rt.sat_mul(5, 4, 8, signed=False)
+    assert value == 20
+    assert not saturated
+
+
+def test_sat_mul_unsigned_saturates_max():
+    value, saturated = rt.sat_mul(20, 20, 8, signed=False)
+    assert value == 255
+    assert saturated
+
+
+def test_sat_mul_unsigned_saturates_min():
+    value, saturated = rt.sat_mul(-20, 20, 8, signed=False)
+    assert value == 0
+    assert saturated
+
+
 def test_no_saturating_overflow_export():
     assert not hasattr(rt, "SaturatingOverflow")


### PR DESCRIPTION
## Summary
- extend runtime tests to cover unsigned cases for saturating addition, subtraction, and multiplication

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530d26f6d48328983cd20390284b17