### PR TITLE
Validate bit width in runtime helpers

### DIFF
--- a/safelang/runtime.py
+++ b/safelang/runtime.py
@@ -9,6 +9,9 @@ from typing import Tuple
 
 
 def bounds(bits: int, signed: bool) -> Tuple[int, int]:
+    if bits <= 0:
+        raise ValueError("bits must be positive")
+
     if signed:
         max_val = 2 ** (bits - 1) - 1
         min_val = -2 ** (bits - 1)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,4 +1,5 @@
 import safelang.runtime as rt
+import pytest
 
 
 def test_sat_add_normal():
@@ -45,3 +46,30 @@ def test_sat_mul_saturates_min():
 
 def test_no_saturating_overflow_export():
     assert not hasattr(rt, "SaturatingOverflow")
+
+
+def test_invalid_bit_width_bounds():
+    with pytest.raises(ValueError):
+        rt.bounds(0, True)
+    with pytest.raises(ValueError):
+        rt.bounds(-1, False)
+
+
+def test_invalid_bit_width_clamp():
+    with pytest.raises(ValueError):
+        rt.clamp(0, 0, True)
+
+
+def test_invalid_bit_width_sat_add():
+    with pytest.raises(ValueError):
+        rt.sat_add(1, 1, 0, True)
+
+
+def test_invalid_bit_width_sat_sub():
+    with pytest.raises(ValueError):
+        rt.sat_sub(1, 1, -8, True)
+
+
+def test_invalid_bit_width_sat_mul():
+    with pytest.raises(ValueError):
+        rt.sat_mul(1, 1, 0, True)


### PR DESCRIPTION
## Summary
- guard against invalid bit widths in `bounds`
- rely on the check in `clamp` and arithmetic helpers
- test that invalid widths raise errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530d2790148328b9df5313219556e2