### PR TITLE
Handle file read errors

### DIFF
--- a/safelang/__main__.py
+++ b/safelang/__main__.py
@@ -2,6 +2,7 @@
 
 import argparse
 from pathlib import Path
+import sys
 from .parser import parse_functions, verify_contracts
 
 
@@ -10,7 +11,11 @@ def main() -> int:
     parser.add_argument("file", type=Path, help="Path to SafeLang source")
     args = parser.parse_args()
 
-    text = args.file.read_text()
+    try:
+        text = args.file.read_text()
+    except (FileNotFoundError, OSError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
     funcs = parse_functions(text)
     errors = verify_contracts(funcs)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,3 +23,10 @@ def test_cli_invalid(tmp_path):
     result = subprocess.run([sys.executable, '-m', 'safelang', str(invalid_file)], capture_output=True, text=True)
     assert result.returncode != 0
     assert 'ERROR' in result.stdout
+
+
+def test_cli_missing_file(tmp_path):
+    missing = tmp_path / 'does_not_exist.slang'
+    result = subprocess.run([sys.executable, '-m', 'safelang', str(missing)], capture_output=True, text=True)
+    assert result.returncode != 0
+    assert 'ERROR' in result.stderr


### PR DESCRIPTION
## Summary
- handle FileNotFoundError/OSError in CLI
- test CLI with missing file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530d295740832893be8b0c73e2b5e3