### PR TITLE
Cleanup test imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for 'pytest' entrypoint
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -2,7 +2,6 @@ import os
 import sys
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from safelang.parser import parse_functions, verify_contracts
 
 


### PR DESCRIPTION
## Summary
- remove per-file path mangling in `test_contracts.py`
- add `conftest.py` to put project root on `sys.path`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68530d2a7b548328b5bd6fdc40b6ec8f