### PR TITLE
Add saturating div/mod operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ function "adjust_thrust" {
 * The Python demo runtime returns the clamped value along with a boolean flag
   indicating whether saturation occurred. No exception is raised on overflow.
 
+The runtime exposes helpers `sat_add`, `sat_sub`, `sat_mul`, `sat_div`, and
+`sat_mod` implementing these semantics.
+
 ```c
 int32 sat_add(int32 a, int32 b)
     int64 sum = (int64)a + (int64)b

--- a/safelang/__init__.py
+++ b/safelang/__init__.py
@@ -1,12 +1,14 @@
 """Minimal demo runtime for the SafeLang compiler."""
 
-from .runtime import sat_add, sat_sub, sat_mul
+from .runtime import sat_add, sat_sub, sat_mul, sat_div, sat_mod
 from .parser import FunctionDef, parse_functions, verify_contracts
 
 __all__ = [
     "sat_add",
     "sat_sub",
     "sat_mul",
+    "sat_div",
+    "sat_mod",
     "FunctionDef",
     "parse_functions",
     "verify_contracts",

--- a/safelang/runtime.py
+++ b/safelang/runtime.py
@@ -53,10 +53,30 @@ def sat_mul(a: int, b: int, bits: int, signed: bool = True) -> Tuple[int, bool]:
     return clamp(total, bits, signed)
 
 
+def sat_div(a: int, b: int, bits: int, signed: bool = True) -> Tuple[int, bool]:
+    """Divide ``a`` by ``b`` with saturating semantics."""
+    bounds(bits, signed)  # validate bit width
+    if int(b) == 0:
+        raise ZeroDivisionError("division by zero")
+    total = int(a) // int(b)
+    return clamp(total, bits, signed)
+
+
+def sat_mod(a: int, b: int, bits: int, signed: bool = True) -> Tuple[int, bool]:
+    """Compute ``a`` modulo ``b`` with saturating semantics."""
+    bounds(bits, signed)  # validate bit width
+    if int(b) == 0:
+        raise ZeroDivisionError("integer modulo by zero")
+    total = int(a) % int(b)
+    return clamp(total, bits, signed)
+
+
 __all__ = [
     "bounds",
     "clamp",
     "sat_add",
     "sat_sub",
     "sat_mul",
+    "sat_div",
+    "sat_mod",
 ]

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -115,3 +115,90 @@ def test_invalid_bit_width_sat_sub():
 def test_invalid_bit_width_sat_mul():
     with pytest.raises(ValueError):
         rt.sat_mul(1, 1, 0, True)
+
+
+def test_sat_div_normal():
+    value, saturated = rt.sat_div(20, 5, 8, signed=True)
+    assert value == 4
+    assert not saturated
+
+
+def test_sat_div_saturates_max():
+    value, saturated = rt.sat_div(200, 1, 8, signed=True)
+    assert value == 127
+    assert saturated
+
+
+def test_sat_div_saturates_min():
+    value, saturated = rt.sat_div(-200, 1, 8, signed=True)
+    assert value == -128
+    assert saturated
+
+
+def test_sat_div_unsigned_normal():
+    value, saturated = rt.sat_div(20, 5, 8, signed=False)
+    assert value == 4
+    assert not saturated
+
+
+def test_sat_div_unsigned_saturates_max():
+    value, saturated = rt.sat_div(600, 1, 8, signed=False)
+    assert value == 255
+    assert saturated
+
+
+def test_sat_div_unsigned_saturates_min():
+    value, saturated = rt.sat_div(-20, 2, 8, signed=False)
+    assert value == 0
+    assert saturated
+
+
+def test_division_by_zero():
+    with pytest.raises(ZeroDivisionError):
+        rt.sat_div(1, 0, 8, signed=True)
+
+
+def test_sat_mod_normal():
+    value, saturated = rt.sat_mod(20, 6, 8, signed=True)
+    assert value == 2
+    assert not saturated
+
+
+def test_sat_mod_saturates_max():
+    value, saturated = rt.sat_mod(150, 200, 8, signed=True)
+    assert value == 127
+    assert saturated
+
+
+def test_sat_mod_saturates_min():
+    value, saturated = rt.sat_mod(-150, -200, 8, signed=True)
+    assert value == -128
+    assert saturated
+
+
+def test_sat_mod_unsigned_normal():
+    value, saturated = rt.sat_mod(20, 6, 8, signed=False)
+    assert value == 2
+    assert not saturated
+
+
+def test_sat_mod_unsigned_saturates_max():
+    value, saturated = rt.sat_mod(300, 400, 8, signed=False)
+    assert value == 255
+    assert saturated
+
+
+def test_sat_mod_unsigned_saturates_min():
+    value, saturated = rt.sat_mod(5, -2, 8, signed=False)
+    assert value == 0
+    assert saturated
+
+
+def test_invalid_bit_width_sat_div():
+    with pytest.raises(ValueError):
+        rt.sat_div(1, 1, 0, True)
+
+
+def test_invalid_bit_width_sat_mod():
+    with pytest.raises(ValueError):
+        rt.sat_mod(1, 1, 0, True)


### PR DESCRIPTION
## Summary
- implement `sat_div` and `sat_mod` in runtime with zero division checks
- expose the helpers via `__all__` and package `__init__`
- extend runtime tests for new operations and edge cases
- document new helpers in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530f105204832884444b58cfcec9e2