### PR TITLE
Add function line limit enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Install the package to expose the ``safelang`` command line tool and run the ver
    Parsed 2 functions successfully.
    ```
 
-   If a function is missing `@space`, `@time`, `consume`, or `emit` blocks, the CLI prints `ERROR:` messages and exits with a non‑zero status.
+   If a function is missing `@space`, `@time`, `consume`, or `emit` blocks, or exceeds the 128 line limit, the CLI prints `ERROR:` messages and exits with a non‑zero status.
 
 3. Alternatively, run the demonstration script which also showcases saturating arithmetic:
 


### PR DESCRIPTION
## Summary
- track line count when parsing functions
- enforce 128 line maximum in `verify_contracts`
- document new check in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685310b7f57c83288928906c0b2db5ab