### PR TITLE
Handle parse errors in CLI

### DIFF
--- a/safelang/__main__.py
+++ b/safelang/__main__.py
@@ -16,7 +16,11 @@ def main() -> int:
     except (FileNotFoundError, OSError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
-    funcs = parse_functions(text)
+    try:
+        funcs = parse_functions(text)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
     errors = verify_contracts(funcs)
 
     if errors:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,15 @@ def test_cli_invalid(tmp_path):
     assert 'ERROR' in result.stdout
 
 
+def test_cli_parse_error(tmp_path):
+    invalid_src = 'function "foo" {'
+    invalid_file = tmp_path / 'bad.slang'
+    invalid_file.write_text(invalid_src)
+    result = subprocess.run([sys.executable, '-m', 'safelang', str(invalid_file)], capture_output=True, text=True)
+    assert result.returncode != 0
+    assert 'ERROR' in result.stderr
+
+
 def test_cli_missing_file(tmp_path):
     missing = tmp_path / 'does_not_exist.slang'
     result = subprocess.run([sys.executable, '-m', 'safelang', str(missing)], capture_output=True, text=True)


### PR DESCRIPTION
## Summary
- make the CLI display parse errors on stderr
- return exit code 1 for parse failures
- test CLI behaviour on malformed SafeLang source

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685312a14fb883289208d6847e1fe906