### PR TITLE
Add coverage hook to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,13 @@ repos:
     hooks:
       - id: black
         language_version: python3
+  - repo: local
+    hooks:
+      - id: coverage
+        name: coverage
+        entry: python scripts/run_coverage.py
+        language: python
+        additional_dependencies:
+          - coverage
+          - pytest
+        pass_filenames: false

--- a/scripts/run_coverage.py
+++ b/scripts/run_coverage.py
@@ -1,0 +1,7 @@
+import subprocess
+import sys
+
+result = subprocess.run([sys.executable, '-m', 'coverage', 'run', '-m', 'pytest'])
+if result.returncode != 0:
+    sys.exit(result.returncode)
+subprocess.run([sys.executable, '-m', 'coverage', 'report'])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,11 +33,15 @@ def test_cli_invalid(tmp_path):
 
 def test_cli_parse_error(tmp_path):
     invalid_src = 'function "foo" {'
-    invalid_file = tmp_path / 'bad.slang'
+    invalid_file = tmp_path / "bad.slang"
     invalid_file.write_text(invalid_src)
-    result = subprocess.run([sys.executable, '-m', 'safelang', str(invalid_file)], capture_output=True, text=True)
+    result = subprocess.run(
+        [sys.executable, "-m", "safelang", str(invalid_file)],
+        capture_output=True,
+        text=True,
+    )
     assert result.returncode != 0
-    assert 'ERROR' in result.stderr
+    assert "ERROR" in result.stderr
 
 
 def test_cli_missing_file(tmp_path):


### PR DESCRIPTION
## Summary
- run pytest with coverage in pre-commit
- add helper script for coverage
- format tests after running black in pre-commit

## Testing
- `pre-commit run --verbose --files $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685313b364388328a3ea4d1568b47518