### PR TITLE
Add pylint to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,9 @@ repos:
     hooks:
       - id: black
         language_version: python3
+  - repo: https://github.com/pycqa/pylint
+    rev: v3.3.1
+    hooks:
+      - id: pylint
+        language_version: python3
+        args: ["-E"]


### PR DESCRIPTION
## Summary
- enable pylint checks in pre-commit config using errors-only mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685313fa02ec8328b796e9a29370ede8