### PR TITLE
Add auto-updated coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pre-commit
+          pip install pytest pre-commit coverage coverage-badge
       - name: Run pre-commit
         run: |
           pre-commit run --files $(git ls-files '*.py') || true
@@ -28,5 +28,17 @@ jobs:
             git commit -am "chore: format code with black"
             git push
           fi
-      - name: Run tests
-        run: pytest -v
+      - name: Generate coverage badge
+        run: |
+          coverage run -m pytest -v
+          coverage xml
+          coverage-badge -o coverage.svg -f
+      - name: Commit coverage badge
+        run: |
+          if ! git diff --quiet; then
+            git config user.name 'github-actions'
+            git config user.email 'github-actions@github.com'
+            git add coverage.svg
+            git commit -am "chore: update coverage badge"
+            git push
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,8 @@ repos:
       - id: pylint
         language_version: python3
         args: ["-E"]
+        additional_dependencies:
+          - pytest
 
   - repo: local
     hooks:
@@ -21,4 +23,5 @@ repos:
         additional_dependencies:
           - coverage
           - pytest
+          - coverage-badge
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SafeLang
 
+![Coverage](coverage.svg)
+
 SafeLang is a programming language designed for **hard real-time, safety-critical embedded systems**, inspired by NASA's 10 rules for developing safety-critical code. It aims to produce software that is provably safe, resilient to overflow and misuse, and adversarially verified.
 
 ## Philosophy

--- a/coverage.svg
+++ b/coverage.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#4c1" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">95%</text>
+        <text x="80" y="14">95%</text>
+    </g>
+</svg>

--- a/scripts/run_coverage.py
+++ b/scripts/run_coverage.py
@@ -1,7 +1,18 @@
 import subprocess
 import sys
 
-result = subprocess.run([sys.executable, "-m", "coverage", "run", "-m", "pytest"])
+result = subprocess.run(
+    [
+        sys.executable,
+        "-m",
+        "coverage",
+        "run",
+        "-m",
+        "pytest",
+    ]
+)
 if result.returncode != 0:
     sys.exit(result.returncode)
-subprocess.run([sys.executable, "-m", "coverage", "report"])
+subprocess.run([sys.executable, "-m", "coverage", "xml"], check=False)
+subprocess.run([sys.executable, "-m", "coverage", "report"], check=False)
+subprocess.run(["coverage-badge", "-o", "coverage.svg", "-f"], check=False)


### PR DESCRIPTION
## Summary
- add coverage badge to README
- update coverage script to produce badge and xml
- install coverage-badge in pre-commit and workflow
- generate and commit coverage badge via CI

## Testing
- `python -m pip install -e .`
- `python -m pip install pytest coverage coverage-badge pre-commit`
- `pytest -q`
- `python -m pre_commit run --files $(git ls-files '*.py')`
- `python scripts/run_coverage.py`

------
https://chatgpt.com/codex/tasks/task_e_6853156777648328ab6853b1fb1d217a