### PR TITLE
Allow comments after @init

### DIFF
--- a/safelang/parser.py
+++ b/safelang/parser.py
@@ -116,6 +116,9 @@ def parse_functions(text: str) -> List[FunctionDef]:
         if line_san.startswith("@init"):
             flagged_init = True
             i += 1
+            # Skip any blank or comment-only lines between @init and the function
+            while i < len(san_lines) and san_lines[i].strip() == "":
+                i += 1
             if i >= len(san_lines):
                 raise ValueError("@init must be followed by a function definition")
             line_san = san_lines[i].strip()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -18,6 +18,14 @@ def test_init_without_function():
         parse_functions("@init")
 
 
+def test_init_followed_by_comment():
+    src = '@init\n! comment\nfunction "foo" { }'
+    funcs = parse_functions(src)
+    assert len(funcs) == 1
+    assert funcs[0].is_init
+    assert funcs[0].name == "foo"
+
+
 def test_unterminated_block():
     src = 'function "foo" {\n    @space 1B'
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- skip blank or comment-only lines after `@init` before checking for `function`
- add parser test covering `@init` followed by comment line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68531d4e09988328a765e58dec7cd8b8