### PR TITLE
Add non-positive time/space checks

### DIFF
--- a/safelang/parser.py
+++ b/safelang/parser.py
@@ -193,10 +193,27 @@ def verify_contracts(funcs: List[FunctionDef]) -> List[str]:
     for fn in funcs:
         if fn.is_init:
             init_count += 1
+
         if not fn.space:
             errors.append(f"Function {fn.name} missing @space")
+        else:
+            try:
+                space_num = int(re.sub(r"[^0-9]", "", fn.space))
+                if space_num <= 0:
+                    errors.append(f"Function {fn.name} has non-positive @space")
+            except ValueError:
+                errors.append(f"Function {fn.name} invalid @space value")
+
         if not fn.time:
             errors.append(f"Function {fn.name} missing @time")
+        else:
+            try:
+                time_num = int(re.sub(r"[^0-9]", "", fn.time))
+                if time_num <= 0:
+                    errors.append(f"Function {fn.name} has non-positive @time")
+            except ValueError:
+                errors.append(f"Function {fn.name} invalid @time value")
+
         if not fn.consume:
             errors.append(f"Function {fn.name} missing consume block")
         if not fn.emit:

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -60,3 +60,15 @@ def test_multiple_init_functions():
     )
     errors = _verify(src, include_init=False)
     assert errors == ["Multiple @init functions defined"]
+
+
+def test_non_positive_space():
+    src = 'function "foo" {\n@space 0B\n@time 1ns\nconsume { nil }\nemit { nil }\n}'
+    errors = _verify(src)
+    assert errors == ["Function foo has non-positive @space"]
+
+
+def test_non_positive_time():
+    src = 'function "bar" {\n@space 1B\n@time 0ns\nconsume { nil }\nemit { nil }\n}'
+    errors = _verify(src)
+    assert errors == ["Function bar has non-positive @time"]


### PR DESCRIPTION
## Summary
- parse numeric values for @space and @time
- raise contract errors when those values are non-positive
- test zero values for both @space and @time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68531d4c229c8328b268d2e7e1270ff7