### PR TITLE
Fix example path resolution for CLI & tests

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,5 +1,7 @@
 """Demonstration of the SafeLang parser and saturating math."""
 
+from pathlib import Path
+
 from safelang import (
     parse_functions,
     verify_contracts,
@@ -8,7 +10,8 @@ from safelang import (
 
 
 def main() -> None:
-    with open("example.slang") as f:
+    example = Path(__file__).resolve().with_name("example.slang")
+    with open(example) as f:
         text = f.read()
 
     funcs = parse_functions(text)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 def test_cli_valid():
-    file = Path("example.slang")
+    file = Path(__file__).resolve().parents[1] / "example.slang"
     result = subprocess.run(
         [sys.executable, "-m", "safelang", str(file)], capture_output=True, text=True
     )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,8 +1,11 @@
 import pytest
+from pathlib import Path
 
 from safelang.parser import parse_functions
 
-EXAMPLE_TEXT = open("example.slang").read()
+EXAMPLE_TEXT = (
+    Path(__file__).resolve().parents[1].joinpath("example.slang").read_text()
+)
 
 
 def test_parse_example():


### PR DESCRIPTION
## Summary
- ensure tests resolve example.slang relative to repo root
- open example.slang in demo.py based on the script's location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68531d49fa748328bd96feaae411cb72