### PR TITLE
Add docstrings across parser, runtime and CLI

### DIFF
--- a/safelang/__main__.py
+++ b/safelang/__main__.py
@@ -7,6 +7,7 @@ from .parser import parse_functions, verify_contracts
 
 
 def main() -> int:
+    """Parse CLI arguments and verify a SafeLang source file."""
     parser = argparse.ArgumentParser(description="SafeLang demo verifier")
     parser.add_argument("file", type=Path, help="Path to SafeLang source")
     args = parser.parse_args()

--- a/safelang/parser.py
+++ b/safelang/parser.py
@@ -7,6 +7,7 @@ from typing import List
 
 @dataclass
 class FunctionDef:
+    """Container for a parsed function's metadata and contracts."""
     name: str
     space: str
     time: str
@@ -191,6 +192,7 @@ def parse_functions(text: str) -> List[FunctionDef]:
 
 
 def verify_contracts(funcs: List[FunctionDef]) -> List[str]:
+    """Check each parsed function for required annotations and limits."""
     errors = []
     init_count = 0
     for fn in funcs:

--- a/safelang/runtime.py
+++ b/safelang/runtime.py
@@ -9,6 +9,10 @@ from typing import Tuple
 
 
 def bounds(bits: int, signed: bool) -> Tuple[int, int]:
+    """Return the minimum and maximum representable values for the width.
+
+    ``signed`` selects between two's complement and unsigned ranges.
+    """
     if bits <= 0:
         raise ValueError("bits must be positive")
 


### PR DESCRIPTION
## Summary
- document FunctionDef dataclass
- explain the `bounds` helper
- clarify contract checks
- describe CLI `main` function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68531f6a341c8328bffd7ac13f75dc62