### PR TITLE
Refactor compiler utilities

### DIFF
--- a/safelang/__init__.py
+++ b/safelang/__init__.py
@@ -3,9 +3,7 @@
 from .runtime import sat_add, sat_sub, sat_mul, sat_div, sat_mod
 from .parser import FunctionDef, parse_functions, verify_contracts
 
-from .compiler import generate_c, generate_rust
-from .compiler import compile_to_nasm
-from .compiler import generate_c
+from .compiler import compile_to_nasm, generate_c, generate_rust
 
 __all__ = [
     "sat_add",

--- a/safelang/__main__.py
+++ b/safelang/__main__.py
@@ -4,9 +4,7 @@ import argparse
 from pathlib import Path
 import sys
 from .parser import parse_functions, verify_contracts
-from .compiler import generate_c, generate_rust
-from .compiler import compile_to_nasm
-from .compiler import generate_c
+from .compiler import compile_to_nasm, generate_c, generate_rust
 
 
 def main() -> int:
@@ -42,8 +40,6 @@ def main() -> int:
         for e in errors:
             print(f"ERROR: {e}")
         return 1
-
-    print(f"Parsed {len(funcs)} functions successfully.")
 
     if args.nasm:
         asm = compile_to_nasm(funcs)

--- a/safelang/compiler.py
+++ b/safelang/compiler.py
@@ -37,13 +37,20 @@ _RUST_TYPE_MAP = {
 _PARAM_RE = re.compile(r"(\w+)\(([^)]+)\)")
 
 
-
 def _parse_params(lines: List[str], type_map: dict, style: str) -> List[str]:
-    """Parse parameters from consume block lines.
-
-    ``type_map`` controls the type names and ``style`` selects
-    formatting ("c" or "rust").
-    """
+    """Parse parameters from ``consume`` block lines."""
+    params: List[str] = []
+    for ln in lines:
+        match = _PARAM_RE.search(ln)
+        if not match:
+            continue
+        typ, name = match.group(1), match.group(2)
+        mapped = type_map.get(typ, "int")
+        if style == "c":
+            params.append(f"{mapped} {name}")
+        else:  # rust
+            params.append(f"{name}: {mapped}")
+    return params
 
 def _parse_space(space: str) -> int:
     match = re.match(r"([0-9_]+)B", space)
@@ -75,20 +82,7 @@ def compile_to_nasm(funcs: List[FunctionDef]) -> str:
         lines.append("    pop rbp")
         lines.append("    ret")
 
-
-def _parse_params(lines: List[str]) -> List[str]:
-    params = []
-    for ln in lines:
-        m = _PARAM_RE.search(ln)
-        if not m:
-            continue
-        typ, name = m.group(1), m.group(2)
-        mapped = type_map.get(typ, "int")
-        if style == "c":
-            params.append(f"{mapped} {name}")
-        else:  # rust
-            params.append(f"{name}: {mapped}")
-    return params
+    return "\n".join(lines)
 
 
 def generate_c(funcs: List[FunctionDef]) -> str:


### PR DESCRIPTION
## Summary
- refactor `_parse_params` in `compiler.py`
- return NASM source from `compile_to_nasm`
- clean up duplicate imports in `__main__` and `__init__`
- avoid duplicate CLI output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685324744c688328913b0bfae0fd3023