### PR TITLE
Add JavaScript runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ function "adjust_thrust" {
 * Arithmetic is performed using a **widened type**, then clamped to the original type's bounds
 * The Python demo runtime returns the clamped value along with a boolean flag
   indicating whether saturation occurred. No exception is raised on overflow.
+* A JavaScript runtime is available in `safelang/runtime.js` providing the same
+  saturating helpers for Node.js environments.
 
 The runtime exposes helpers `sat_add`, `sat_sub`, `sat_mul`, `sat_div`, and
 `sat_mod` implementing these semantics.

--- a/safelang/runtime.js
+++ b/safelang/runtime.js
@@ -1,0 +1,76 @@
+// SafeLang JavaScript runtime helpers for saturating arithmetic.
+//
+// Each helper returns an object { value, saturated } describing the result of
+// the operation and whether clamping occurred. All arithmetic is performed
+// using JavaScript BigInts to avoid precision loss for 64-bit operations.
+
+'use strict';
+
+function bounds(bits, signed = true) {
+  if (bits <= 0) {
+    throw new Error('bits must be positive');
+  }
+  if (signed) {
+    const max = (1n << BigInt(bits - 1)) - 1n;
+    const min = -(1n << BigInt(bits - 1));
+    return { min, max };
+  }
+  const max = (1n << BigInt(bits)) - 1n;
+  return { min: 0n, max };
+}
+
+function clamp(value, bits, signed = true) {
+  const { min, max } = bounds(bits, signed);
+  let bigint = BigInt(value);
+  if (bigint > max) {
+    return { value: max, saturated: true };
+  }
+  if (bigint < min) {
+    return { value: min, saturated: true };
+  }
+  return { value: bigint, saturated: false };
+}
+
+function satAdd(a, b, bits, signed = true) {
+  const total = BigInt(a) + BigInt(b);
+  return clamp(total, bits, signed);
+}
+
+function satSub(a, b, bits, signed = true) {
+  const total = BigInt(a) - BigInt(b);
+  return clamp(total, bits, signed);
+}
+
+function satMul(a, b, bits, signed = true) {
+  const total = BigInt(a) * BigInt(b);
+  return clamp(total, bits, signed);
+}
+
+function satDiv(a, b, bits, signed = true) {
+  bounds(bits, signed); // validate bit width
+  if (BigInt(b) === 0n) {
+    throw new Error('division by zero');
+  }
+  const total = BigInt(a) / BigInt(b);
+  return clamp(total, bits, signed);
+}
+
+function satMod(a, b, bits, signed = true) {
+  bounds(bits, signed); // validate bit width
+  if (BigInt(b) === 0n) {
+    throw new Error('integer modulo by zero');
+  }
+  const total = BigInt(a) % BigInt(b);
+  return clamp(total, bits, signed);
+}
+
+module.exports = {
+  bounds,
+  clamp,
+  satAdd,
+  satSub,
+  satMul,
+  satDiv,
+  satMod,
+};
+


### PR DESCRIPTION
## Summary
- implement saturating arithmetic helpers for JavaScript
- mention the new runtime in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68532556684c8328a4444bb77f3fea4d