### PR TITLE
Add portable C runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ function "adjust_thrust" {
 
 The runtime exposes helpers `sat_add`, `sat_sub`, `sat_mul`, `sat_div`, and
 `sat_mod` implementing these semantics.
+A portable C implementation of these helpers is available under
+`runtime-c/` for use with generated C code.
 
 ```c
 int32 sat_add(int32 a, int32 b)

--- a/runtime-c/README.md
+++ b/runtime-c/README.md
@@ -1,0 +1,25 @@
+# SafeLang C Runtime
+
+This directory provides a minimal C implementation of SafeLang's
+saturating arithmetic helpers.  The routines mirror the behavior of the
+Python runtime found in `safelang/runtime.py`.
+
+The API exposes a `sl_result_t` structure which contains the clamped
+result and a flag indicating whether saturation occurred.
+
+```
+sl_result_t sl_sat_add(int64_t a, int64_t b, int bits, bool signed);
+```
+
+All operations abort on invalid bit width or division by zero. The
+functions support bit widths up to 63 bits.
+
+Compile the runtime into a static library:
+
+```
+cc -c safelang_runtime.c -o safelang_runtime.o
+ar rcs libsafelang.a safelang_runtime.o
+```
+
+You can then link `libsafelang.a` with generated C code from the
+SafeLang compiler.

--- a/runtime-c/safelang_runtime.c
+++ b/runtime-c/safelang_runtime.c
@@ -1,0 +1,85 @@
+#include "safelang_runtime.h"
+#include <stdlib.h> /* for abort */
+
+static void check_bits(int bits) {
+    if (bits <= 0 || bits > 63) {
+        abort();
+    }
+}
+
+void sl_bounds(int bits, bool signed_arith, int64_t *min_out, int64_t *max_out) {
+    check_bits(bits);
+    if (signed_arith) {
+        int64_t max_val = ((int64_t)1 << (bits - 1)) - 1;
+        int64_t min_val = -((int64_t)1 << (bits - 1));
+        if (min_out) *min_out = min_val;
+        if (max_out) *max_out = max_val;
+    } else {
+        int64_t max_val = ((int64_t)1 << bits) - 1;
+        int64_t min_val = 0;
+        if (min_out) *min_out = min_val;
+        if (max_out) *max_out = max_val;
+    }
+}
+
+static sl_result_t clamp_internal(int64_t value, int64_t min_val, int64_t max_val) {
+    sl_result_t result;
+    if (value > max_val) {
+        result.value = max_val;
+        result.saturated = true;
+    } else if (value < min_val) {
+        result.value = min_val;
+        result.saturated = true;
+    } else {
+        result.value = value;
+        result.saturated = false;
+    }
+    return result;
+}
+
+sl_result_t sl_clamp(int64_t value, int bits, bool signed_arith) {
+    int64_t min_v, max_v;
+    sl_bounds(bits, signed_arith, &min_v, &max_v);
+    return clamp_internal(value, min_v, max_v);
+}
+
+sl_result_t sl_sat_add(int64_t a, int64_t b, int bits, bool signed_arith) {
+    int64_t total = a + b;
+    int64_t min_v, max_v;
+    sl_bounds(bits, signed_arith, &min_v, &max_v);
+    return clamp_internal(total, min_v, max_v);
+}
+
+sl_result_t sl_sat_sub(int64_t a, int64_t b, int bits, bool signed_arith) {
+    int64_t total = a - b;
+    int64_t min_v, max_v;
+    sl_bounds(bits, signed_arith, &min_v, &max_v);
+    return clamp_internal(total, min_v, max_v);
+}
+
+sl_result_t sl_sat_mul(int64_t a, int64_t b, int bits, bool signed_arith) {
+    int64_t total = a * b;
+    int64_t min_v, max_v;
+    sl_bounds(bits, signed_arith, &min_v, &max_v);
+    return clamp_internal(total, min_v, max_v);
+}
+
+sl_result_t sl_sat_div(int64_t a, int64_t b, int bits, bool signed_arith) {
+    if (b == 0) {
+        abort();
+    }
+    int64_t total = a / b;
+    int64_t min_v, max_v;
+    sl_bounds(bits, signed_arith, &min_v, &max_v);
+    return clamp_internal(total, min_v, max_v);
+}
+
+sl_result_t sl_sat_mod(int64_t a, int64_t b, int bits, bool signed_arith) {
+    if (b == 0) {
+        abort();
+    }
+    int64_t total = a % b;
+    int64_t min_v, max_v;
+    sl_bounds(bits, signed_arith, &min_v, &max_v);
+    return clamp_internal(total, min_v, max_v);
+}

--- a/runtime-c/safelang_runtime.h
+++ b/runtime-c/safelang_runtime.h
@@ -1,0 +1,42 @@
+#ifndef SAFELANG_RUNTIME_H
+#define SAFELANG_RUNTIME_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Result of a saturating arithmetic operation. */
+typedef struct {
+    int64_t value;     /* clamped result */
+    bool saturated;    /* whether saturation occurred */
+} sl_result_t;
+
+/** Compute representable bounds for the specified bit width. */
+void sl_bounds(int bits, bool signed_arith, int64_t *min_out, int64_t *max_out);
+
+/** Clamp the given value to the representable range. */
+sl_result_t sl_clamp(int64_t value, int bits, bool signed_arith);
+
+/** Saturating addition. */
+sl_result_t sl_sat_add(int64_t a, int64_t b, int bits, bool signed_arith);
+
+/** Saturating subtraction. */
+sl_result_t sl_sat_sub(int64_t a, int64_t b, int bits, bool signed_arith);
+
+/** Saturating multiplication. */
+sl_result_t sl_sat_mul(int64_t a, int64_t b, int bits, bool signed_arith);
+
+/** Saturating division. Division by zero aborts. */
+sl_result_t sl_sat_div(int64_t a, int64_t b, int bits, bool signed_arith);
+
+/** Saturating modulo. Division by zero aborts. */
+sl_result_t sl_sat_mod(int64_t a, int64_t b, int bits, bool signed_arith);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SAFELANG_RUNTIME_H */


### PR DESCRIPTION
## Summary
- implement SafeLang saturating runtime helpers in C
- document the new C runtime
- mention C runtime in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685325505ee4832888fc2884a85824b5