### PR TITLE
Detect duplicate function names

### DIFF
--- a/safelang/parser.py
+++ b/safelang/parser.py
@@ -198,7 +198,13 @@ def verify_contracts(funcs: List[FunctionDef]) -> List[str]:
     """Check each parsed function for required annotations and limits."""
     errors = []
     init_count = 0
+    seen_names = set()
     for fn in funcs:
+        if fn.name in seen_names:
+            errors.append(f"Duplicate function name {fn.name}")
+        else:
+            seen_names.add(fn.name)
+
         if fn.is_init:
             init_count += 1
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -87,3 +87,22 @@ def test_function_exceeds_line_limit():
     )
     errors = _verify(src)
     assert "Function foo exceeds 128 line limit" in errors
+
+
+def test_duplicate_function_name():
+    src = (
+        'function "dup" {\n'
+        '@space 1B\n'
+        '@time 1ns\n'
+        'consume { nil }\n'
+        'emit { nil }\n'
+        '}\n'
+        'function "dup" {\n'
+        '@space 1B\n'
+        '@time 1ns\n'
+        'consume { nil }\n'
+        'emit { nil }\n'
+        '}'
+    )
+    errors = _verify(src)
+    assert "Duplicate function name dup" in errors


### PR DESCRIPTION
## Summary
- flag duplicate function names during contract verification
- test duplicate name detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68532c7aa890832894d082223d1e0552