### PR TITLE
Enforce mutually exclusive emit options

### DIFF
--- a/safelang/__main__.py
+++ b/safelang/__main__.py
@@ -12,12 +12,13 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="SafeLang demo verifier")
     parser.add_argument("file", type=Path, help="Path to SafeLang source")
     parser.add_argument("--nasm", type=Path, help="Write NASM output to file")
-    parser.add_argument(
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
         "--emit-c",
         action="store_true",
         help="Output generated C instead of verification result",
     )
-    parser.add_argument(
+    group.add_argument(
         "--emit-rust",
         action="store_true",
         help="Output generated Rust instead of verification result",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,3 +83,21 @@ def test_cli_emit_nasm(tmp_path):
     )
     assert result.returncode == 0
     assert out_file.read_text().startswith("; Auto-generated NASM")
+
+
+def test_cli_emit_conflict():
+    file = Path(__file__).resolve().parents[1] / "example.slang"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "safelang",
+            "--emit-c",
+            "--emit-rust",
+            str(file),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    assert "usage:" in result.stderr.lower()


### PR DESCRIPTION
## Summary
- use `argparse.add_mutually_exclusive_group` for `--emit-c` and `--emit-rust`
- add CLI test for conflicting emit flags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685969c7825883288d20e53a367fcb8f