### PR TITLE
Enforce bit width limits in runtime

### DIFF
--- a/safelang/runtime.py
+++ b/safelang/runtime.py
@@ -9,12 +9,15 @@ from typing import Tuple
 
 
 def bounds(bits: int, signed: bool) -> Tuple[int, int]:
-    """Return the minimum and maximum representable values for the width.
+    """Return the minimum and maximum representable values for ``bits``.
 
-    ``signed`` selects between two's complement and unsigned ranges.
+    ``signed`` selects between two's complement and unsigned ranges. ``bits``
+    must be between 1 and 63 inclusive to match the C runtime limits.
     """
     if bits <= 0:
         raise ValueError("bits must be positive")
+    if bits > 63:
+        raise ValueError("bits must be 63 or less")
 
     if signed:
         max_val = 2 ** (bits - 1) - 1

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -95,26 +95,36 @@ def test_invalid_bit_width_bounds():
         rt.bounds(0, True)
     with pytest.raises(ValueError):
         rt.bounds(-1, False)
+    with pytest.raises(ValueError):
+        rt.bounds(64, True)
 
 
 def test_invalid_bit_width_clamp():
     with pytest.raises(ValueError):
         rt.clamp(0, 0, True)
+    with pytest.raises(ValueError):
+        rt.clamp(0, 64, True)
 
 
 def test_invalid_bit_width_sat_add():
     with pytest.raises(ValueError):
         rt.sat_add(1, 1, 0, True)
+    with pytest.raises(ValueError):
+        rt.sat_add(1, 1, 64, True)
 
 
 def test_invalid_bit_width_sat_sub():
     with pytest.raises(ValueError):
         rt.sat_sub(1, 1, -8, True)
+    with pytest.raises(ValueError):
+        rt.sat_sub(1, 1, 64, True)
 
 
 def test_invalid_bit_width_sat_mul():
     with pytest.raises(ValueError):
         rt.sat_mul(1, 1, 0, True)
+    with pytest.raises(ValueError):
+        rt.sat_mul(1, 1, 64, True)
 
 
 def test_sat_div_normal():
@@ -197,8 +207,12 @@ def test_sat_mod_unsigned_saturates_min():
 def test_invalid_bit_width_sat_div():
     with pytest.raises(ValueError):
         rt.sat_div(1, 1, 0, True)
+    with pytest.raises(ValueError):
+        rt.sat_div(1, 1, 64, True)
 
 
 def test_invalid_bit_width_sat_mod():
     with pytest.raises(ValueError):
         rt.sat_mod(1, 1, 0, True)
+    with pytest.raises(ValueError):
+        rt.sat_mod(1, 1, 64, True)


### PR DESCRIPTION
## Summary
- add bit width range checks to `bounds`
- document the valid range in the Python runtime
- test for oversized bit widths in the runtime helpers

## Testing
- `pre-commit run --files safelang/runtime.py tests/test_runtime.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685969c9aaec83289462dab34650f5f1