### PR TITLE
Add assembly stack assertions

### DIFF
--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -7,6 +7,10 @@ def test_compile_to_nasm(tmp_path):
     funcs = parse_functions(src.read_text())
     asm = compile_to_nasm(funcs)
     assert "clamp_params_init:" in asm
+    init_block = asm.split("clamp_params_init:")[1].split("clamp_params:")[0]
+    assert "sub rsp, 512" in init_block
+    params_block = asm.split("clamp_params:")[1]
+    assert "sub rsp, 128" in params_block
     out = tmp_path / "out.asm"
     out.write_text(asm)
     assert out.read_text().startswith("; Auto-generated NASM")


### PR DESCRIPTION
## Summary
- extend compiler test to assert exact stack space for functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685969c907448328a89667525056d995