### PR TITLE
Validate contract units

### DIFF
--- a/safelang/parser.py
+++ b/safelang/parser.py
@@ -152,8 +152,8 @@ def parse_functions(text: str) -> List[FunctionDef]:
             body = text[next_open + 1 : end_pos]
             line_count = body.count("\n") + 1 if body else 0
 
-            space_match = re.search(r"@space\s+([0-9]+B)", body)
-            time_match = re.search(r"@time\s+([0-9_]+ns)", body)
+            space_match = re.search(r"@space\s+(\S+)", body)
+            time_match = re.search(r"@time\s+(\S+)", body)
             consume_block = re.search(r"consume\s*{([^}]*)}", body, re.S)
             emit_block = re.search(r"emit\s*{([^}]*)}", body, re.S)
 
@@ -211,22 +211,28 @@ def verify_contracts(funcs: List[FunctionDef]) -> List[str]:
         if not fn.space:
             errors.append(f"Function {fn.name} missing @space")
         else:
-            try:
-                space_num = int(re.sub(r"[^0-9]", "", fn.space))
-                if space_num <= 0:
-                    errors.append(f"Function {fn.name} has non-positive @space")
-            except ValueError:
+            if not re.fullmatch(r"[0-9_]+B", fn.space):
                 errors.append(f"Function {fn.name} invalid @space value")
+            else:
+                try:
+                    space_num = int(re.sub(r"[^0-9]", "", fn.space))
+                    if space_num <= 0:
+                        errors.append(f"Function {fn.name} has non-positive @space")
+                except ValueError:
+                    errors.append(f"Function {fn.name} invalid @space value")
 
         if not fn.time:
             errors.append(f"Function {fn.name} missing @time")
         else:
-            try:
-                time_num = int(re.sub(r"[^0-9]", "", fn.time))
-                if time_num <= 0:
-                    errors.append(f"Function {fn.name} has non-positive @time")
-            except ValueError:
+            if not re.fullmatch(r"[0-9_]+ns", fn.time):
                 errors.append(f"Function {fn.name} invalid @time value")
+            else:
+                try:
+                    time_num = int(re.sub(r"[^0-9]", "", fn.time))
+                    if time_num <= 0:
+                        errors.append(f"Function {fn.name} has non-positive @time")
+                except ValueError:
+                    errors.append(f"Function {fn.name} invalid @time value")
 
         if not fn.consume:
             errors.append(f"Function {fn.name} missing consume block")

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -106,3 +106,27 @@ def test_duplicate_function_name():
     )
     errors = _verify(src)
     assert "Duplicate function name dup" in errors
+
+
+def test_space_invalid_format():
+    src = 'function "foo" {\n@space abcB\n@time 1ns\nconsume { nil }\nemit { nil }\n}'
+    errors = _verify(src)
+    assert errors == ["Function foo invalid @space value"]
+
+
+def test_time_invalid_format():
+    src = 'function "foo" {\n@space 1B\n@time 1ms\nconsume { nil }\nemit { nil }\n}'
+    errors = _verify(src)
+    assert errors == ["Function foo invalid @time value"]
+
+
+def test_space_missing_unit():
+    src = 'function "foo" {\n@space 10\n@time 1ns\nconsume { nil }\nemit { nil }\n}'
+    errors = _verify(src)
+    assert errors == ["Function foo invalid @space value"]
+
+
+def test_time_missing_unit():
+    src = 'function "foo" {\n@space 1B\n@time 10\nconsume { nil }\nemit { nil }\n}'
+    errors = _verify(src)
+    assert errors == ["Function foo invalid @time value"]


### PR DESCRIPTION
## Summary
- allow parser to capture raw `@space`/`@time` tokens
- ensure contract units match `^[0-9_]+B$` and `^[0-9_]+ns$`
- test malformed contract values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d5b1936688328a9481863c66068a9