### PR TITLE
Enforce bit width limits in JS runtime

### DIFF
--- a/safelang/runtime.js
+++ b/safelang/runtime.js
@@ -10,6 +10,9 @@ function bounds(bits, signed = true) {
   if (bits <= 0) {
     throw new Error('bits must be positive');
   }
+  if (bits > 63) {
+    throw new Error('bits must be 63 or less');
+  }
   if (signed) {
     const max = (1n << BigInt(bits - 1)) - 1n;
     const min = -(1n << BigInt(bits - 1));

--- a/tests/test_runtime_js.py
+++ b/tests/test_runtime_js.py
@@ -2,27 +2,33 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
 import safelang.runtime as rt
 
 RUNTIME_JS = Path(__file__).resolve().parents[1] / "safelang" / "runtime.js"
 
 
-def _call_js(func: str, a, b, bits: int, signed: bool = True):
-    snippet = (
-        f"const rt = require({json.dumps(str(RUNTIME_JS))});\n"
-        f"const res = rt.{func}({a}, {b}, {bits}, {str(signed).lower()});\n"
-        "console.log(JSON.stringify({value: res.value.toString(), saturated: res.saturated}));"
-    )
+def _run_js(snippet: str, check: bool = True):
+    """Execute a small JS snippet using Node."""
     result = subprocess.run(
         [
             "node",
             "-e",
-            snippet,
+            f"const rt = require({json.dumps(str(RUNTIME_JS))});\n" + snippet,
         ],
         capture_output=True,
         text=True,
-        check=True,
+        check=check,
     )
+    return result
+
+
+def _call_js(func: str, a, b, bits: int, signed: bool = True):
+    snippet = (
+        f"const res = rt.{func}({a}, {b}, {bits}, {str(signed).lower()});\n"
+        "console.log(JSON.stringify({value: res.value.toString(), saturated: res.saturated}));"
+    )
+    result = _run_js(snippet)
     out = json.loads(result.stdout.strip())
     return int(out["value"]), out["saturated"]
 
@@ -100,3 +106,45 @@ def test_sat_mod_js_matches_py():
         py_val, py_sat = rt.sat_mod(a, b, 8, True)
         js_val, js_sat = _call_js("satMod", a, b, 8, True)
         assert (js_val, js_sat) == (py_val, py_sat)
+
+
+def test_invalid_bit_width_bounds_js():
+    for bits in [0, -1, 64]:
+        with pytest.raises(subprocess.CalledProcessError):
+            _run_js(f"rt.bounds({bits}, true);")
+
+
+def test_invalid_bit_width_clamp_js():
+    for bits in [0, 64]:
+        with pytest.raises(subprocess.CalledProcessError):
+            _run_js(f"rt.clamp(0, {bits}, true);")
+
+
+def test_invalid_bit_width_sat_add_js():
+    for bits in [0, 64]:
+        with pytest.raises(subprocess.CalledProcessError):
+            _run_js(f"rt.satAdd(1, 1, {bits}, true);")
+
+
+def test_invalid_bit_width_sat_sub_js():
+    for bits in [-8, 64]:
+        with pytest.raises(subprocess.CalledProcessError):
+            _run_js(f"rt.satSub(1, 1, {bits}, true);")
+
+
+def test_invalid_bit_width_sat_mul_js():
+    for bits in [0, 64]:
+        with pytest.raises(subprocess.CalledProcessError):
+            _run_js(f"rt.satMul(1, 1, {bits}, true);")
+
+
+def test_invalid_bit_width_sat_div_js():
+    for bits in [0, 64]:
+        with pytest.raises(subprocess.CalledProcessError):
+            _run_js(f"rt.satDiv(1, 1, {bits}, true);")
+
+
+def test_invalid_bit_width_sat_mod_js():
+    for bits in [0, 64]:
+        with pytest.raises(subprocess.CalledProcessError):
+            _run_js(f"rt.satMod(1, 1, {bits}, true);")


### PR DESCRIPTION
## Summary
- prevent bit widths over 63 in `runtime.js`
- extend JS runtime tests for invalid bit sizes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bfe720bd483289417146775077ee3