### PR TITLE
Detect unterminated comment or string

### DIFF
--- a/safelang/parser.py
+++ b/safelang/parser.py
@@ -27,6 +27,8 @@ def _sanitize(text: str) -> str:
     length = len(text)
     in_string = None
     in_block_comment = False
+    string_start = None
+    block_start = None
 
     while i < length:
         ch = text[i]
@@ -49,6 +51,7 @@ def _sanitize(text: str) -> str:
 
         if text.startswith("/*", i):
             in_block_comment = True
+            block_start = i
             result.append("  ")
             i += 2
             continue
@@ -67,12 +70,20 @@ def _sanitize(text: str) -> str:
 
         if ch in {'"', "'"}:
             in_string = ch
+            string_start = i
             result.append(" ")
             i += 1
             continue
 
         result.append(ch)
         i += 1
+
+    if in_block_comment:
+        line = text.count("\n", 0, block_start) + 1
+        raise ValueError(f"Unterminated block comment starting at line {line}")
+    if in_string:
+        line = text.count("\n", 0, string_start) + 1
+        raise ValueError(f"Unterminated string starting at line {line}")
 
     return "".join(result)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -97,3 +97,15 @@ def test_block_comment():
     )
     funcs = parse_functions(src)
     assert len(funcs) == 1
+
+
+def test_unterminated_block_comment():
+    src = 'function "foo" { /* comment'
+    with pytest.raises(ValueError, match="Unterminated block comment"):
+        parse_functions(src)
+
+
+def test_unterminated_string():
+    src = 'function "foo" { msg = "unterminated }'
+    with pytest.raises(ValueError, match="Unterminated string"):
+        parse_functions(src)


### PR DESCRIPTION
## Summary
- raise `ValueError` when `_sanitize` hits EOF with an open block comment or string
- test malformed inputs producing these errors

## Testing
- `pytest tests/test_parser.py`
- `pre-commit run --files safelang/parser.py tests/test_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_6893c4f4867883288d5d41fbd34a1d16