### PR TITLE
Implement C-style truncation for division and modulo

### DIFF
--- a/safelang/runtime.py
+++ b/safelang/runtime.py
@@ -63,19 +63,38 @@ def sat_mul(a: int, b: int, bits: int, signed: bool = True) -> Tuple[int, bool]:
 def sat_div(a: int, b: int, bits: int, signed: bool = True) -> Tuple[int, bool]:
     """Divide ``a`` by ``b`` with saturating semantics."""
     bounds(bits, signed)  # validate bit width
-    if int(b) == 0:
+    a_int = int(a)
+    b_int = int(b)
+    if b_int == 0:
         raise ZeroDivisionError("division by zero")
-    total = int(a) // int(b)
-    return clamp(total, bits, signed)
+    if not signed and (a_int < 0 or b_int < 0):
+        return 0, True
+
+    abs_a = abs(a_int)
+    abs_b = abs(b_int)
+    quotient = abs_a // abs_b
+    if (a_int < 0) ^ (b_int < 0):
+        quotient = -quotient
+    return clamp(quotient, bits, signed)
 
 
 def sat_mod(a: int, b: int, bits: int, signed: bool = True) -> Tuple[int, bool]:
     """Compute ``a`` modulo ``b`` with saturating semantics."""
     bounds(bits, signed)  # validate bit width
-    if int(b) == 0:
+    a_int = int(a)
+    b_int = int(b)
+    if b_int == 0:
         raise ZeroDivisionError("integer modulo by zero")
-    total = int(a) % int(b)
-    return clamp(total, bits, signed)
+    if not signed and (a_int < 0 or b_int < 0):
+        return 0, True
+
+    abs_a = abs(a_int)
+    abs_b = abs(b_int)
+    quotient = abs_a // abs_b
+    if (a_int < 0) ^ (b_int < 0):
+        quotient = -quotient
+    remainder = a_int - quotient * b_int
+    return clamp(remainder, bits, signed)
 
 
 __all__ = [

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -145,6 +145,18 @@ def test_sat_div_saturates_min():
     assert saturated
 
 
+def test_sat_div_c_truncation():
+    value, saturated = rt.sat_div(-7, 3, 8, signed=True)
+    assert value == -2
+    assert not saturated
+    value, saturated = rt.sat_div(7, -3, 8, signed=True)
+    assert value == -2
+    assert not saturated
+    value, saturated = rt.sat_div(-7, -3, 8, signed=True)
+    assert value == 2
+    assert not saturated
+
+
 def test_sat_div_unsigned_normal():
     value, saturated = rt.sat_div(20, 5, 8, signed=False)
     assert value == 4
@@ -184,6 +196,18 @@ def test_sat_mod_saturates_min():
     value, saturated = rt.sat_mod(-150, -200, 8, signed=True)
     assert value == -128
     assert saturated
+
+
+def test_sat_mod_c_signed():
+    value, saturated = rt.sat_mod(-7, 3, 8, signed=True)
+    assert value == -1
+    assert not saturated
+    value, saturated = rt.sat_mod(7, -3, 8, signed=True)
+    assert value == 1
+    assert not saturated
+    value, saturated = rt.sat_mod(-7, -3, 8, signed=True)
+    assert value == -1
+    assert not saturated
 
 
 def test_sat_mod_unsigned_normal():


### PR DESCRIPTION
## Summary
- align `sat_div` and `sat_mod` with C-style truncation toward zero using absolute values and sign adjustments
- broaden runtime tests to cover negative divisor/dividend combinations

## Testing
- `pytest tests/test_runtime.py`


------
https://chatgpt.com/codex/tasks/task_e_6893c4e615548328bca24fc1752becab