### PR TITLE
Support memory unit suffixes for @space parsing

### DIFF
--- a/safelang/compiler.py
+++ b/safelang/compiler.py
@@ -54,10 +54,46 @@ def _parse_params(lines: List[str], type_map: dict, style: str) -> List[str]:
 
 
 def _parse_space(space: str) -> int:
-    match = re.match(r"([0-9_]+)B", space)
+    """Parse a memory size string into bytes.
+
+    Recognizes suffixes like ``B``, ``KB``, ``MB`` and converts the numeric
+    portion (allowing underscores for readability) into its byte equivalent.
+
+    Parameters
+    ----------
+    space: str
+        A string representing the memory size (e.g. ``"4KB"``).
+
+    Returns
+    -------
+    int
+        The size in bytes.
+
+    Raises
+    ------
+    ValueError
+        If the format is not recognized.
+    """
+
+    space = space.strip().upper()
+    match = re.fullmatch(r"([0-9_]+)([KMGT]?B)", space)
     if not match:
-        return 0
-    return int(match.group(1).replace("_", ""))
+        raise ValueError(f"Unrecognized space format: {space}")
+
+    number = int(match.group(1).replace("_", ""))
+    suffix = match.group(2)
+    multipliers = {
+        "B": 1,
+        "KB": 1024,
+        "MB": 1024**2,
+        "GB": 1024**3,
+        "TB": 1024**4,
+    }
+
+    try:
+        return number * multipliers[suffix]
+    except KeyError as exc:
+        raise ValueError(f"Unrecognized space format: {space}") from exc
 
 
 def compile_to_nasm(funcs: List[FunctionDef]) -> str:

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,5 +1,9 @@
 from pathlib import Path
+
+import pytest
+
 from safelang import parse_functions, compile_to_nasm
+from safelang.compiler import _parse_space
 
 
 def test_compile_to_nasm(tmp_path):
@@ -14,3 +18,16 @@ def test_compile_to_nasm(tmp_path):
     out = tmp_path / "out.asm"
     out.write_text(asm)
     assert out.read_text().startswith("; Auto-generated NASM")
+
+
+def test_parse_space_units():
+    assert _parse_space("1B") == 1
+    assert _parse_space("2KB") == 2 * 1024
+    assert _parse_space("3MB") == 3 * 1024 * 1024
+
+
+def test_parse_space_invalid():
+    with pytest.raises(ValueError):
+        _parse_space("10XB")
+    with pytest.raises(ValueError):
+        _parse_space("foo")


### PR DESCRIPTION
## Summary
- expand `_parse_space` to handle B/KB/MB/GB/TB and error on invalid formats
- add unit tests covering space parsing and invalid cases

## Testing
- `pre-commit run --files safelang/compiler.py tests/test_compiler.py`
- `pytest tests/test_compiler.py`


------
https://chatgpt.com/codex/tasks/task_e_6893c4ec11a483289d30a74a93eb029b