### PR TITLE
Add unsigned operand validation to JS runtime

### DIFF
--- a/safelang/runtime.js
+++ b/safelang/runtime.js
@@ -35,35 +35,60 @@ function clamp(value, bits, signed = true) {
 }
 
 function satAdd(a, b, bits, signed = true) {
-  const total = BigInt(a) + BigInt(b);
+  const ia = BigInt(a);
+  const ib = BigInt(b);
+  if (!signed && (ia < 0n || ib < 0n)) {
+    throw new Error('negative operands not allowed in unsigned mode');
+  }
+  const total = ia + ib;
   return clamp(total, bits, signed);
 }
 
 function satSub(a, b, bits, signed = true) {
-  const total = BigInt(a) - BigInt(b);
+  const ia = BigInt(a);
+  const ib = BigInt(b);
+  if (!signed && (ia < 0n || ib < 0n)) {
+    throw new Error('negative operands not allowed in unsigned mode');
+  }
+  const total = ia - ib;
   return clamp(total, bits, signed);
 }
 
 function satMul(a, b, bits, signed = true) {
-  const total = BigInt(a) * BigInt(b);
+  const ia = BigInt(a);
+  const ib = BigInt(b);
+  if (!signed && (ia < 0n || ib < 0n)) {
+    throw new Error('negative operands not allowed in unsigned mode');
+  }
+  const total = ia * ib;
   return clamp(total, bits, signed);
 }
 
 function satDiv(a, b, bits, signed = true) {
   bounds(bits, signed); // validate bit width
-  if (BigInt(b) === 0n) {
+  const ia = BigInt(a);
+  const ib = BigInt(b);
+  if (ib === 0n) {
     throw new Error('division by zero');
   }
-  const total = BigInt(a) / BigInt(b);
+  if (!signed && (ia < 0n || ib < 0n)) {
+    throw new Error('negative operands not allowed in unsigned mode');
+  }
+  const total = ia / ib;
   return clamp(total, bits, signed);
 }
 
 function satMod(a, b, bits, signed = true) {
   bounds(bits, signed); // validate bit width
-  if (BigInt(b) === 0n) {
+  const ia = BigInt(a);
+  const ib = BigInt(b);
+  if (ib === 0n) {
     throw new Error('integer modulo by zero');
   }
-  const total = BigInt(a) % BigInt(b);
+  if (!signed && (ia < 0n || ib < 0n)) {
+    throw new Error('negative operands not allowed in unsigned mode');
+  }
+  const total = ia % ib;
   return clamp(total, bits, signed);
 }
 

--- a/safelang/runtime.py
+++ b/safelang/runtime.py
@@ -95,20 +95,11 @@ def sat_div(a: int, b: int, bits: int, signed: bool = True) -> Tuple[int, bool]:
         raise ZeroDivisionError("division by zero")
     if not signed and (ia < 0 or ib < 0):
         raise ValueError("negative operands not allowed in unsigned mode")
-    total = ia // ib
-    return clamp(total, bits, signed)
 
-    a_int = int(a)
-    b_int = int(b)
-    if b_int == 0:
-        raise ZeroDivisionError("division by zero")
-    if not signed and (a_int < 0 or b_int < 0):
-        return 0, True
-
-    abs_a = abs(a_int)
-    abs_b = abs(b_int)
+    abs_a = abs(ia)
+    abs_b = abs(ib)
     quotient = abs_a // abs_b
-    if (a_int < 0) ^ (b_int < 0):
+    if (ia < 0) ^ (ib < 0):
         quotient = -quotient
     return clamp(quotient, bits, signed)
 
@@ -126,22 +117,13 @@ def sat_mod(a: int, b: int, bits: int, signed: bool = True) -> Tuple[int, bool]:
         raise ZeroDivisionError("integer modulo by zero")
     if not signed and (ia < 0 or ib < 0):
         raise ValueError("negative operands not allowed in unsigned mode")
-    total = ia % ib
-    return clamp(total, bits, signed)
 
-    a_int = int(a)
-    b_int = int(b)
-    if b_int == 0:
-        raise ZeroDivisionError("integer modulo by zero")
-    if not signed and (a_int < 0 or b_int < 0):
-        return 0, True
-
-    abs_a = abs(a_int)
-    abs_b = abs(b_int)
+    abs_a = abs(ia)
+    abs_b = abs(ib)
     quotient = abs_a // abs_b
-    if (a_int < 0) ^ (b_int < 0):
+    if (ia < 0) ^ (ib < 0):
         quotient = -quotient
-    remainder = a_int - quotient * b_int
+    remainder = ia - quotient * ib
     return clamp(remainder, bits, signed)
 
 

--- a/tests/test_runtime_js.py
+++ b/tests/test_runtime_js.py
@@ -48,6 +48,12 @@ def test_sat_add_js_matches_py():
         assert (js_val, js_sat) == (py_val, py_sat)
 
 
+def test_sat_add_unsigned_negative_error_js():
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        _run_js("rt.satAdd(-1, 2, 8, false);")
+    assert "negative operands not allowed in unsigned mode" in exc.value.stderr
+
+
 # Test satSub
 
 
@@ -61,6 +67,12 @@ def test_sat_sub_js_matches_py():
         py_val, py_sat = rt.sat_sub(a, b, 8, True)
         js_val, js_sat = _call_js("satSub", a, b, 8, True)
         assert (js_val, js_sat) == (py_val, py_sat)
+
+
+def test_sat_sub_unsigned_negative_error_js():
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        _run_js("rt.satSub(-1, 1, 8, false);")
+    assert "negative operands not allowed in unsigned mode" in exc.value.stderr
 
 
 # Test satMul
@@ -78,6 +90,12 @@ def test_sat_mul_js_matches_py():
         assert (js_val, js_sat) == (py_val, py_sat)
 
 
+def test_sat_mul_unsigned_negative_error_js():
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        _run_js("rt.satMul(-2, 3, 8, false);")
+    assert "negative operands not allowed in unsigned mode" in exc.value.stderr
+
+
 # Test satDiv
 
 
@@ -93,6 +111,12 @@ def test_sat_div_js_matches_py():
         assert (js_val, js_sat) == (py_val, py_sat)
 
 
+def test_sat_div_unsigned_negative_error_js():
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        _run_js("rt.satDiv(-4, 2, 8, false);")
+    assert "negative operands not allowed in unsigned mode" in exc.value.stderr
+
+
 # Test satMod
 
 
@@ -106,6 +130,12 @@ def test_sat_mod_js_matches_py():
         py_val, py_sat = rt.sat_mod(a, b, 8, True)
         js_val, js_sat = _call_js("satMod", a, b, 8, True)
         assert (js_val, js_sat) == (py_val, py_sat)
+
+
+def test_sat_mod_unsigned_negative_error_js():
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        _run_js("rt.satMod(5, -2, 8, false);")
+    assert "negative operands not allowed in unsigned mode" in exc.value.stderr
 
 
 def test_invalid_bit_width_bounds_js():


### PR DESCRIPTION
## Summary
- Reject negative operands in JavaScript saturating arithmetic helpers when operating in unsigned mode and mirror Python error messages
- Ensure Python runtime division and modulo follow C-style truncation semantics
- Add tests for unsigned negative operand errors across JS runtime helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d27bf03d88328aa06f727547a37ef