### PR TITLE
Abort unsigned ops on negative operands in C runtime

### DIFF
--- a/runtime-c/README.md
+++ b/runtime-c/README.md
@@ -11,8 +11,9 @@ result and a flag indicating whether saturation occurred.
 sl_result_t sl_sat_add(int64_t a, int64_t b, int bits, bool signed);
 ```
 
-All operations abort on invalid bit width or division by zero. The
-functions support bit widths up to 63 bits.
+All operations abort on invalid bit width, division by zero, or when
+negative operands are supplied to unsigned arithmetic. The functions
+support bit widths up to 63 bits.
 
 Compile the runtime into a static library:
 

--- a/runtime-c/safelang_runtime.c
+++ b/runtime-c/safelang_runtime.c
@@ -44,6 +44,9 @@ sl_result_t sl_clamp(int64_t value, int bits, bool signed_arith) {
 }
 
 sl_result_t sl_sat_add(int64_t a, int64_t b, int bits, bool signed_arith) {
+    if (!signed_arith && (a < 0 || b < 0)) {
+        abort();
+    }
     int64_t total = a + b;
     int64_t min_v, max_v;
     sl_bounds(bits, signed_arith, &min_v, &max_v);
@@ -51,6 +54,9 @@ sl_result_t sl_sat_add(int64_t a, int64_t b, int bits, bool signed_arith) {
 }
 
 sl_result_t sl_sat_sub(int64_t a, int64_t b, int bits, bool signed_arith) {
+    if (!signed_arith && (a < 0 || b < 0)) {
+        abort();
+    }
     int64_t total = a - b;
     int64_t min_v, max_v;
     sl_bounds(bits, signed_arith, &min_v, &max_v);
@@ -58,6 +64,9 @@ sl_result_t sl_sat_sub(int64_t a, int64_t b, int bits, bool signed_arith) {
 }
 
 sl_result_t sl_sat_mul(int64_t a, int64_t b, int bits, bool signed_arith) {
+    if (!signed_arith && (a < 0 || b < 0)) {
+        abort();
+    }
     int64_t total = a * b;
     int64_t min_v, max_v;
     sl_bounds(bits, signed_arith, &min_v, &max_v);
@@ -65,6 +74,9 @@ sl_result_t sl_sat_mul(int64_t a, int64_t b, int bits, bool signed_arith) {
 }
 
 sl_result_t sl_sat_div(int64_t a, int64_t b, int bits, bool signed_arith) {
+    if (!signed_arith && (a < 0 || b < 0)) {
+        abort();
+    }
     if (b == 0) {
         abort();
     }
@@ -75,6 +87,9 @@ sl_result_t sl_sat_div(int64_t a, int64_t b, int bits, bool signed_arith) {
 }
 
 sl_result_t sl_sat_mod(int64_t a, int64_t b, int bits, bool signed_arith) {
+    if (!signed_arith && (a < 0 || b < 0)) {
+        abort();
+    }
     if (b == 0) {
         abort();
     }

--- a/runtime-c/safelang_runtime.h
+++ b/runtime-c/safelang_runtime.h
@@ -20,19 +20,19 @@ void sl_bounds(int bits, bool signed_arith, int64_t *min_out, int64_t *max_out);
 /** Clamp the given value to the representable range. */
 sl_result_t sl_clamp(int64_t value, int bits, bool signed_arith);
 
-/** Saturating addition. */
+/** Saturating addition. Aborts if unsigned and either operand is negative. */
 sl_result_t sl_sat_add(int64_t a, int64_t b, int bits, bool signed_arith);
 
-/** Saturating subtraction. */
+/** Saturating subtraction. Aborts if unsigned and either operand is negative. */
 sl_result_t sl_sat_sub(int64_t a, int64_t b, int bits, bool signed_arith);
 
-/** Saturating multiplication. */
+/** Saturating multiplication. Aborts if unsigned and either operand is negative. */
 sl_result_t sl_sat_mul(int64_t a, int64_t b, int bits, bool signed_arith);
 
-/** Saturating division. Division by zero aborts. */
+/** Saturating division. Aborts on division by zero or if unsigned with negative operands. */
 sl_result_t sl_sat_div(int64_t a, int64_t b, int bits, bool signed_arith);
 
-/** Saturating modulo. Division by zero aborts. */
+/** Saturating modulo. Aborts on division by zero or if unsigned with negative operands. */
 sl_result_t sl_sat_mod(int64_t a, int64_t b, int bits, bool signed_arith);
 
 #ifdef __cplusplus

--- a/tests/test_runtime_c.py
+++ b/tests/test_runtime_c.py
@@ -1,0 +1,39 @@
+import subprocess
+import tempfile
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+RUNTIME_C = ROOT / "runtime-c" / "safelang_runtime.c"
+INCLUDE_DIR = ROOT / "runtime-c"
+
+def run_program(source: str) -> int:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src_path = Path(tmpdir) / "test.c"
+        src_path.write_text(source)
+        exe_path = Path(tmpdir) / "test"
+        subprocess.run([
+            "cc",
+            src_path,
+            str(RUNTIME_C),
+            "-I",
+            str(INCLUDE_DIR),
+            "-o",
+            exe_path,
+        ], check=True)
+        result = subprocess.run([exe_path])
+        return result.returncode
+
+@pytest.mark.parametrize("a,b", [(-1,1),(1,-1)])
+@pytest.mark.parametrize("func", ["add", "sub", "mul", "div", "mod"])
+def test_unsigned_negative_operands(func, a, b):
+    call = f"sl_sat_{func}({a}, {b}, 8, false);"
+    source = f"""
+#include \"safelang_runtime.h\"
+int main() {{
+    {call}
+    return 0;
+}}
+"""
+    rc = run_program(source)
+    assert rc == -6


### PR DESCRIPTION
## Summary
- abort saturating arithmetic when unsigned operations see negative operands
- document unsigned negative-operand aborts in C runtime README and headers
- add C runtime tests verifying negative operands abort

## Testing
- `pytest tests/test_runtime_c.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d27be3a748328b3392e6bd8f7cef1