### PR TITLE
refactor: rely on clamp for division and modulo

### DIFF
--- a/safelang/runtime.py
+++ b/safelang/runtime.py
@@ -88,27 +88,16 @@ def sat_div(a: int, b: int, bits: int, signed: bool = True) -> Tuple[int, bool]:
         ZeroDivisionError: If ``b`` is zero.
         ValueError: If ``signed`` is ``False`` and either operand is negative.
     """
-    bounds(bits, signed)  # validate bit width
-
     ia, ib = int(a), int(b)
     if ib == 0:
         raise ZeroDivisionError("division by zero")
     if not signed and (ia < 0 or ib < 0):
         raise ValueError("negative operands not allowed in unsigned mode")
-    total = ia // ib
-    return clamp(total, bits, signed)
 
-    a_int = int(a)
-    b_int = int(b)
-    if b_int == 0:
-        raise ZeroDivisionError("division by zero")
-    if not signed and (a_int < 0 or b_int < 0):
-        return 0, True
-
-    abs_a = abs(a_int)
-    abs_b = abs(b_int)
+    abs_a = abs(ia)
+    abs_b = abs(ib)
     quotient = abs_a // abs_b
-    if (a_int < 0) ^ (b_int < 0):
+    if (ia < 0) ^ (ib < 0):
         quotient = -quotient
     return clamp(quotient, bits, signed)
 
@@ -120,28 +109,18 @@ def sat_mod(a: int, b: int, bits: int, signed: bool = True) -> Tuple[int, bool]:
         ZeroDivisionError: If ``b`` is zero.
         ValueError: If ``signed`` is ``False`` and either operand is negative.
     """
-    bounds(bits, signed)  # validate bit width
     ia, ib = int(a), int(b)
     if ib == 0:
         raise ZeroDivisionError("integer modulo by zero")
     if not signed and (ia < 0 or ib < 0):
         raise ValueError("negative operands not allowed in unsigned mode")
-    total = ia % ib
-    return clamp(total, bits, signed)
 
-    a_int = int(a)
-    b_int = int(b)
-    if b_int == 0:
-        raise ZeroDivisionError("integer modulo by zero")
-    if not signed and (a_int < 0 or b_int < 0):
-        return 0, True
-
-    abs_a = abs(a_int)
-    abs_b = abs(b_int)
+    abs_a = abs(ia)
+    abs_b = abs(ib)
     quotient = abs_a // abs_b
-    if (a_int < 0) ^ (b_int < 0):
+    if (ia < 0) ^ (ib < 0):
         quotient = -quotient
-    remainder = a_int - quotient * b_int
+    remainder = ia - quotient * ib
     return clamp(remainder, bits, signed)
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -247,3 +247,13 @@ def test_invalid_bit_width_sat_mod():
         rt.sat_mod(1, 1, 0, True)
     with pytest.raises(ValueError):
         rt.sat_mod(1, 1, 64, True)
+
+
+def test_sat_div_zero_precedence_over_invalid_bits():
+    with pytest.raises(ZeroDivisionError):
+        rt.sat_div(1, 0, 0, signed=True)
+
+
+def test_sat_mod_zero_precedence_over_invalid_bits():
+    with pytest.raises(ZeroDivisionError):
+        rt.sat_mod(1, 0, 0, signed=True)


### PR DESCRIPTION
## Summary
- use absolute-value approach for sat_div and sat_mod so only one set of operand checks remains
- handle bit-width validation via clamp and remove unreachable code
- extend runtime tests for division/modulo zero precedence

## Testing
- `pre-commit run --files safelang/runtime.py tests/test_runtime.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d27bfe26c8328abc9e9350fccd794