### PR TITLE
Validate parameter format and surface CLI errors

### DIFF
--- a/safelang/__main__.py
+++ b/safelang/__main__.py
@@ -49,13 +49,17 @@ def main() -> int:
         except OSError as exc:
             print(f"ERROR: {exc}", file=sys.stderr)
             return 1
-    if args.emit_c:
-        print(generate_c(funcs))
-    elif args.emit_rust:
-        print(generate_rust(funcs))
-    else:
-        print(f"Parsed {len(funcs)} functions successfully.")
-    return 0
+    try:
+        if args.emit_c:
+            print(generate_c(funcs))
+        elif args.emit_rust:
+            print(generate_rust(funcs))
+        else:
+            print(f"Parsed {len(funcs)} functions successfully.")
+        return 0
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/safelang/compiler.py
+++ b/safelang/compiler.py
@@ -41,9 +41,12 @@ def _parse_params(lines: List[str], type_map: dict, style: str) -> List[str]:
     """Parse parameters from ``consume`` block lines."""
     params: List[str] = []
     for ln in lines:
-        match = _PARAM_RE.search(ln)
-        if not match:
+        stripped = ln.split("#", 1)[0].split("!", 1)[0].strip()
+        if stripped == "nil":
             continue
+        match = _PARAM_RE.fullmatch(stripped)
+        if not match:
+            raise ValueError(f"Malformed parameter: {ln}")
         typ, name = match.group(1), match.group(2)
         mapped = type_map.get(typ)
         if mapped is None:

--- a/safelang/runtime.py
+++ b/safelang/runtime.py
@@ -90,20 +90,12 @@ def sat_div(a: int, b: int, bits: int, signed: bool = True) -> Tuple[int, bool]:
     """
     bounds(bits, signed)  # validate bit width
 
-    ia, ib = int(a), int(b)
-    if ib == 0:
-        raise ZeroDivisionError("division by zero")
-    if not signed and (ia < 0 or ib < 0):
-        raise ValueError("negative operands not allowed in unsigned mode")
-    total = ia // ib
-    return clamp(total, bits, signed)
-
     a_int = int(a)
     b_int = int(b)
     if b_int == 0:
         raise ZeroDivisionError("division by zero")
     if not signed and (a_int < 0 or b_int < 0):
-        return 0, True
+        raise ValueError("negative operands not allowed in unsigned mode")
 
     abs_a = abs(a_int)
     abs_b = abs(b_int)
@@ -121,20 +113,13 @@ def sat_mod(a: int, b: int, bits: int, signed: bool = True) -> Tuple[int, bool]:
         ValueError: If ``signed`` is ``False`` and either operand is negative.
     """
     bounds(bits, signed)  # validate bit width
-    ia, ib = int(a), int(b)
-    if ib == 0:
-        raise ZeroDivisionError("integer modulo by zero")
-    if not signed and (ia < 0 or ib < 0):
-        raise ValueError("negative operands not allowed in unsigned mode")
-    total = ia % ib
-    return clamp(total, bits, signed)
 
     a_int = int(a)
     b_int = int(b)
     if b_int == 0:
         raise ZeroDivisionError("integer modulo by zero")
     if not signed and (a_int < 0 or b_int < 0):
-        return 0, True
+        raise ValueError("negative operands not allowed in unsigned mode")
 
     abs_a = abs(a_int)
     abs_b = abs(b_int)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,6 +75,33 @@ def test_cli_emit_rust():
     assert "pub fn clamp_params(" in result.stdout
 
 
+def test_cli_emit_c_malformed(tmp_path):
+    malformed_src = (
+        '@init\n'
+        'function "init" {\n'
+        "    @space 1B\n"
+        "    @time 1ns\n"
+        "    consume { nil }\n"
+        "    emit { nil }\n"
+        "}\n"
+        'function "foo" {\n'
+        "    @space 1B\n"
+        "    @time 1ns\n"
+        "    consume { int64 x }\n"
+        "    emit { nil }\n"
+        "}\n"
+    )
+    malformed_file = tmp_path / "malformed.slang"
+    malformed_file.write_text(malformed_src)
+    result = subprocess.run(
+        [sys.executable, "-m", "safelang", "--emit-c", str(malformed_file)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "ERROR" in result.stderr
+
+
 def test_cli_emit_nasm(tmp_path):
     src = Path(__file__).resolve().parents[1] / "example.slang"
     out_file = tmp_path / "out.asm"

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -20,6 +20,17 @@ function "bad" {
     return parse_functions(src)
 
 
+def _load_malformed_funcs():
+    src = """
+function "bad" {
+    @space 0B
+    @time 0
+    consume { int64 x }
+}
+"""
+    return parse_functions(src)
+
+
 def test_generate_c_contains_clamp_params():
     funcs = _load_example_funcs()
     c_code = generate_c(funcs)
@@ -68,4 +79,16 @@ def test_generate_c_unknown_type_raises():
 def test_generate_rust_unknown_type_raises():
     funcs = _load_bad_funcs()
     with pytest.raises(ValueError, match="Unknown type: foo"):
+        generate_rust(funcs)
+
+
+def test_generate_c_malformed_param_raises():
+    funcs = _load_malformed_funcs()
+    with pytest.raises(ValueError, match="Malformed parameter"):
+        generate_c(funcs)
+
+
+def test_generate_rust_malformed_param_raises():
+    funcs = _load_malformed_funcs()
+    with pytest.raises(ValueError, match="Malformed parameter"):
         generate_rust(funcs)


### PR DESCRIPTION
## Summary
- enforce strict `type(name)` parsing in `_parse_params`, ignoring comments and `nil`
- report parameter parsing errors via CLI
- add tests for malformed parameters and CLI error handling
- fix runtime division and modulo helpers to use C-style truncation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d27bdaff08328b0945f3248fed23d