### PR TITLE
Raise error on nested block comments

### DIFF
--- a/safelang/parser.py
+++ b/safelang/parser.py
@@ -33,6 +33,8 @@ def _sanitize(text: str) -> str:
     while i < length:
         ch = text[i]
         if in_block_comment:
+            if text.startswith("/*", i):
+                raise ValueError("Nested block comments are not supported")
             if ch == "*" and i + 1 < length and text[i + 1] == "/":
                 result.append("  ")
                 i += 2

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -99,6 +99,14 @@ def test_block_comment():
     assert len(funcs) == 1
 
 
+def test_nested_block_comment_error():
+    src = 'function "foo" { /* outer /* inner */ outer end */ }'
+    with pytest.raises(
+        ValueError, match="Nested block comments are not supported"
+    ):
+        parse_functions(src)
+
+
 def test_unterminated_block_comment():
     src = 'function "foo" { /* comment'
     with pytest.raises(ValueError, match="Unterminated block comment"):


### PR DESCRIPTION
## Summary
- prevent nested block comments in the parser's sanitizer
- test that nested block comments raise a ValueError

## Testing
- `pytest tests/test_parser.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f4c88f03c8328913e1694c1f10b05