### PR TITLE
Raise error for too many parameters in NASM codegen

### DIFF
--- a/safelang/compiler.py
+++ b/safelang/compiler.py
@@ -187,8 +187,10 @@ def compile_to_nasm(funcs: List[FunctionDef]) -> str:
         var_regs = {}
         for idx, ln in enumerate(fn.consume):
             match = _PARAM_RE.search(ln)
-            if not match or idx >= len(_PARAM_REGS):
+            if not match:
                 continue
+            if idx >= len(_PARAM_REGS):
+                raise ValueError(f"{fn.name}: too many parameters")
             var_regs[match.group(2)] = _PARAM_REGS[idx]
 
         for stmt in _extract_body(fn.body):

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -70,6 +70,32 @@ function "add" {
     assert "add rax, rsi" in asm
 
 
+def test_compile_to_nasm_too_many_params():
+    src = """
+function "many" {
+    @space 0B
+    @time 0ns
+
+    consume {
+        int64(p1)
+        int64(p2)
+        int64(p3)
+        int64(p4)
+        int64(p5)
+        int64(p6)
+        int64(p7)
+    }
+
+    emit { int64(r) }
+
+    return p1
+}
+"""
+    funcs = parse_functions(src)
+    with pytest.raises(ValueError, match="too many parameters"):
+        compile_to_nasm(funcs)
+
+
 def test_generate_c_unknown_type_raises():
     funcs = _load_bad_funcs()
     with pytest.raises(ValueError, match="Unknown type: foo"):


### PR DESCRIPTION
## Summary
- Raise an error when compile_to_nasm sees more than six parameters
- Test that NASM code generation rejects functions with excess parameters

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f4c83979483288518b1cf4a0ac924