### PR TITLE
feat: add C/Rust output file options to CLI

### DIFF
--- a/safelang/__main__.py
+++ b/safelang/__main__.py
@@ -23,6 +23,8 @@ def main() -> int:
         action="store_true",
         help="Output generated Rust instead of verification result",
     )
+    group.add_argument("--c-out", type=Path, help="Write generated C to file")
+    group.add_argument("--rust-out", type=Path, help="Write generated Rust to file")
     args = parser.parse_args()
 
     try:
@@ -50,10 +52,26 @@ def main() -> int:
             print(f"ERROR: {exc}", file=sys.stderr)
             return 1
     try:
-        if args.emit_c:
-            print(generate_c(funcs))
-        elif args.emit_rust:
-            print(generate_rust(funcs))
+        if args.emit_c or args.c_out:
+            code = generate_c(funcs)
+            if args.c_out:
+                try:
+                    args.c_out.write_text(code)
+                except OSError as exc:
+                    print(f"ERROR: {exc}", file=sys.stderr)
+                    return 1
+            else:
+                print(code)
+        elif args.emit_rust or args.rust_out:
+            code = generate_rust(funcs)
+            if args.rust_out:
+                try:
+                    args.rust_out.write_text(code)
+                except OSError as exc:
+                    print(f"ERROR: {exc}", file=sys.stderr)
+                    return 1
+            else:
+                print(code)
         else:
             print(f"Parsed {len(funcs)} functions successfully.")
         return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,6 +75,32 @@ def test_cli_emit_rust():
     assert "pub fn clamp_params(" in result.stdout
 
 
+def test_cli_c_out(tmp_path):
+    file = Path(__file__).resolve().parents[1] / "example.slang"
+    out_file = tmp_path / "out.c"
+    result = subprocess.run(
+        [sys.executable, "-m", "safelang", "--c-out", str(out_file), str(file)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert "#include <stdint.h>" in out_file.read_text()
+
+
+def test_cli_rust_out(tmp_path):
+    file = Path(__file__).resolve().parents[1] / "example.slang"
+    out_file = tmp_path / "out.rs"
+    result = subprocess.run(
+        [sys.executable, "-m", "safelang", "--rust-out", str(out_file), str(file)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert "pub fn clamp_params(" in out_file.read_text()
+
+
 def test_cli_emit_c_malformed(tmp_path):
     malformed_src = (
         "@init\n"


### PR DESCRIPTION
## Summary
- support `--c-out` and `--rust-out` flags to write generated code to files
- test CLI file output options for C and Rust

## Testing
- `pre-commit run --files safelang/__main__.py tests/test_cli.py`
- `pytest tests/test_cli.py::test_cli_c_out tests/test_cli.py::test_cli_rust_out -q`


------
https://chatgpt.com/codex/tasks/task_e_689f4c7b5d3883288112233cfee59f5e