### PR TITLE
Check negative operands in unsigned JS runtime math

### DIFF
--- a/safelang/runtime.js
+++ b/safelang/runtime.js
@@ -35,16 +35,25 @@ function clamp(value, bits, signed = true) {
 }
 
 function satAdd(a, b, bits, signed = true) {
+  if (!signed && (BigInt(a) < 0n || BigInt(b) < 0n)) {
+    throw new Error('negative operands not allowed in unsigned mode');
+  }
   const total = BigInt(a) + BigInt(b);
   return clamp(total, bits, signed);
 }
 
 function satSub(a, b, bits, signed = true) {
+  if (!signed && (BigInt(a) < 0n || BigInt(b) < 0n)) {
+    throw new Error('negative operands not allowed in unsigned mode');
+  }
   const total = BigInt(a) - BigInt(b);
   return clamp(total, bits, signed);
 }
 
 function satMul(a, b, bits, signed = true) {
+  if (!signed && (BigInt(a) < 0n || BigInt(b) < 0n)) {
+    throw new Error('negative operands not allowed in unsigned mode');
+  }
   const total = BigInt(a) * BigInt(b);
   return clamp(total, bits, signed);
 }
@@ -54,6 +63,9 @@ function satDiv(a, b, bits, signed = true) {
   if (BigInt(b) === 0n) {
     throw new Error('division by zero');
   }
+  if (!signed && (BigInt(a) < 0n || BigInt(b) < 0n)) {
+    throw new Error('negative operands not allowed in unsigned mode');
+  }
   const total = BigInt(a) / BigInt(b);
   return clamp(total, bits, signed);
 }
@@ -62,6 +74,9 @@ function satMod(a, b, bits, signed = true) {
   bounds(bits, signed); // validate bit width
   if (BigInt(b) === 0n) {
     throw new Error('integer modulo by zero');
+  }
+  if (!signed && (BigInt(a) < 0n || BigInt(b) < 0n)) {
+    throw new Error('negative operands not allowed in unsigned mode');
   }
   const total = BigInt(a) % BigInt(b);
   return clamp(total, bits, signed);

--- a/tests/test_runtime_js.py
+++ b/tests/test_runtime_js.py
@@ -108,6 +108,19 @@ def test_sat_mod_js_matches_py():
         assert (js_val, js_sat) == (py_val, py_sat)
 
 
+def test_unsigned_negative_operands_js():
+    with pytest.raises(subprocess.CalledProcessError):
+        _run_js("rt.satAdd(-1, 2, 8, false);")
+    with pytest.raises(subprocess.CalledProcessError):
+        _run_js("rt.satSub(-1, 1, 8, false);")
+    with pytest.raises(subprocess.CalledProcessError):
+        _run_js("rt.satMul(-20, 20, 8, false);")
+    with pytest.raises(subprocess.CalledProcessError):
+        _run_js("rt.satDiv(-20, 2, 8, false);")
+    with pytest.raises(subprocess.CalledProcessError):
+        _run_js("rt.satMod(5, -2, 8, false);")
+
+
 def test_invalid_bit_width_bounds_js():
     for bits in [0, -1, 64]:
         with pytest.raises(subprocess.CalledProcessError):


### PR DESCRIPTION
## Summary
- Reject negative operands for unsigned saturating arithmetic in JavaScript runtime
- Add regression tests ensuring negative operands trigger errors in unsigned mode

## Testing
- `pytest tests/test_runtime_js.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f4c72663c8328836e357e6de11640