### PR TITLE
Handle escaped quotes in parser sanitizer

### DIFF
--- a/safelang/parser.py
+++ b/safelang/parser.py
@@ -47,7 +47,16 @@ def _sanitize(text: str) -> str:
         if in_string:
             result.append("\n" if ch == "\n" else " ")
             if ch == in_string:
-                in_string = None
+                # Count preceding backslashes to see if this quote is escaped.
+                bs_count = 0
+                j = i - 1
+                while j >= 0 and text[j] == "\\":
+                    bs_count += 1
+                    j -= 1
+                # Only terminate the string if the number of backslashes is even
+                # (i.e. the quote is not escaped).
+                if bs_count % 2 == 0:
+                    in_string = None
             i += 1
             continue
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -57,6 +57,18 @@ def test_braces_in_string():
     assert len(funcs) == 1
 
 
+def test_escaped_double_quote_in_string():
+    src = 'function "foo" { msg = "say \"hi\"" }'
+    funcs = parse_functions(src)
+    assert len(funcs) == 1
+
+
+def test_escaped_single_quote_in_string():
+    src = "function \"foo\" { msg = 'it\\'s fine' }"
+    funcs = parse_functions(src)
+    assert len(funcs) == 1
+
+
 def test_line_start_hash_comment():
     src = (
         'function "foo" {\n'


### PR DESCRIPTION
## Summary
- improve string sanitization to ignore escaped quotes
- add tests for escaped single and double quotes

## Testing
- `pytest tests/test_parser.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3549eb00c83288e65ea0196b0bf84