### PR TITLE
Allow larger @space units

### DIFF
--- a/safelang/parser.py
+++ b/safelang/parser.py
@@ -256,7 +256,7 @@ def verify_contracts(funcs: List[FunctionDef]) -> List[str]:
 
         _validate_numeric_attr(
             fn.space,
-            r"[0-9_]+B",
+            r"[0-9_]+[KMGT]?B",
             errors,
             f"Function {fn.name} missing @space",
             f"Function {fn.name} invalid @space value",

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -136,3 +136,15 @@ def test_numeric_with_underscores():
     src = 'function "foo" {\n@space 1_024B\n@time 1_000ns\nconsume { nil }\nemit { nil }\n}'
     errors = _verify(src)
     assert errors == []
+
+
+def test_space_kilobytes():
+    src = 'function "kbytes" {\n@space 1KB\n@time 1ns\nconsume { nil }\nemit { nil }\n}'
+    errors = _verify(src)
+    assert errors == []
+
+
+def test_space_megabytes():
+    src = 'function "mbytes" {\n@space 2MB\n@time 1ns\nconsume { nil }\nemit { nil }\n}'
+    errors = _verify(src)
+    assert errors == []


### PR DESCRIPTION
## Summary
- allow @space annotations with KB/MB/GB/TB units
- test contract validator with 1KB and 2MB budgets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3549f52ac8328b3e0ef781da35f83