### PR TITLE
feat: robust expression tokenization

### DIFF
--- a/safelang/compiler.py
+++ b/safelang/compiler.py
@@ -109,12 +109,22 @@ def _mov_to_rax(token: str, var_regs: dict) -> str:
     return f"mov rax, {src}"
 
 
+_TOKEN_RE = re.compile(r"\w+|[-+*/]")
+
+
+def _tokenize(expr: str) -> List[str]:
+    return _TOKEN_RE.findall(expr)
+
+
 def _compile_expr(expr: str, var_regs: dict) -> List[str]:
-    tokens = expr.split()
+    tokens = _tokenize(expr)
     if not tokens:
         return []
     if len(tokens) == 1:
         return [_mov_to_rax(tokens[0], var_regs)]
+    if len(tokens) == 2 and tokens[0] == "-":
+        rhs_val = var_regs.get(tokens[1], tokens[1])
+        return ["mov rax, 0", f"sub rax, {rhs_val}"]
     if len(tokens) == 3:
         lhs, op, rhs = tokens
         code = [_mov_to_rax(lhs, var_regs)]

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from safelang import parse_functions, compile_to_nasm
-from safelang.compiler import _parse_space
+from safelang.compiler import _parse_space, _compile_expr
 
 
 def test_compile_to_nasm(tmp_path):
@@ -18,6 +18,21 @@ def test_compile_to_nasm(tmp_path):
     out = tmp_path / "out.asm"
     out.write_text(asm)
     assert out.read_text().startswith("; Auto-generated NASM")
+
+
+def test_compile_expr_addition():
+    var_regs = {"a": "rdi", "b": "rsi"}
+    assert _compile_expr("a+b", var_regs) == ["mov rax, rdi", "add rax, rsi"]
+
+
+def test_compile_expr_subtraction():
+    var_regs = {"a": "rdi", "b": "rsi"}
+    assert _compile_expr("a-b", var_regs) == ["mov rax, rdi", "sub rax, rsi"]
+
+
+def test_compile_expr_unary_minus():
+    var_regs = {"a": "rdi"}
+    assert _compile_expr("-a", var_regs) == ["mov rax, 0", "sub rax, rdi"]
 
 
 def test_parse_space_units():


### PR DESCRIPTION
## Summary
- replace whitespace split with regex-based tokenizer for expression compilation
- support unary minus and operator-adjacent operands
- add tests for a+b, a-b, and -a scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a354a1a6d48328b7ec5307435aae64