### PR TITLE
Abort on negative operands in unsigned C runtime

### DIFF
--- a/runtime-c/README.md
+++ b/runtime-c/README.md
@@ -11,8 +11,9 @@ result and a flag indicating whether saturation occurred.
 sl_result_t sl_sat_add(int64_t a, int64_t b, int bits, bool signed);
 ```
 
-All operations abort on invalid bit width or division by zero. The
-functions support bit widths up to 63 bits.
+All operations abort on invalid bit width, division by zero, or negative
+operands when `signed` is `false`. The functions support bit widths up to
+63 bits.
 
 Compile the runtime into a static library:
 

--- a/runtime-c/safelang_runtime.c
+++ b/runtime-c/safelang_runtime.c
@@ -44,6 +44,9 @@ sl_result_t sl_clamp(int64_t value, int bits, bool signed_arith) {
 }
 
 sl_result_t sl_sat_add(int64_t a, int64_t b, int bits, bool signed_arith) {
+    if (!signed_arith && (a < 0 || b < 0)) {
+        abort();
+    }
     int64_t total = a + b;
     int64_t min_v, max_v;
     sl_bounds(bits, signed_arith, &min_v, &max_v);
@@ -51,6 +54,9 @@ sl_result_t sl_sat_add(int64_t a, int64_t b, int bits, bool signed_arith) {
 }
 
 sl_result_t sl_sat_sub(int64_t a, int64_t b, int bits, bool signed_arith) {
+    if (!signed_arith && (a < 0 || b < 0)) {
+        abort();
+    }
     int64_t total = a - b;
     int64_t min_v, max_v;
     sl_bounds(bits, signed_arith, &min_v, &max_v);
@@ -58,6 +64,9 @@ sl_result_t sl_sat_sub(int64_t a, int64_t b, int bits, bool signed_arith) {
 }
 
 sl_result_t sl_sat_mul(int64_t a, int64_t b, int bits, bool signed_arith) {
+    if (!signed_arith && (a < 0 || b < 0)) {
+        abort();
+    }
     int64_t total = a * b;
     int64_t min_v, max_v;
     sl_bounds(bits, signed_arith, &min_v, &max_v);
@@ -65,6 +74,9 @@ sl_result_t sl_sat_mul(int64_t a, int64_t b, int bits, bool signed_arith) {
 }
 
 sl_result_t sl_sat_div(int64_t a, int64_t b, int bits, bool signed_arith) {
+    if (!signed_arith && (a < 0 || b < 0)) {
+        abort();
+    }
     if (b == 0) {
         abort();
     }
@@ -75,6 +87,9 @@ sl_result_t sl_sat_div(int64_t a, int64_t b, int bits, bool signed_arith) {
 }
 
 sl_result_t sl_sat_mod(int64_t a, int64_t b, int bits, bool signed_arith) {
+    if (!signed_arith && (a < 0 || b < 0)) {
+        abort();
+    }
     if (b == 0) {
         abort();
     }

--- a/tests/runtime_c_unsigned_harness.c
+++ b/tests/runtime_c_unsigned_harness.c
@@ -1,0 +1,18 @@
+#include "safelang_runtime.h"
+
+int main(void) {
+#ifdef TEST_ADD
+    sl_sat_add(-1, 1, 8, false);
+#elif defined(TEST_SUB)
+    sl_sat_sub(-1, 1, 8, false);
+#elif defined(TEST_MUL)
+    sl_sat_mul(-1, 1, 8, false);
+#elif defined(TEST_DIV)
+    sl_sat_div(-1, 1, 8, false);
+#elif defined(TEST_MOD)
+    sl_sat_mod(-1, 1, 8, false);
+#else
+#error "No test operation defined"
+#endif
+    return 0;
+}

--- a/tests/test_runtime_c_unsigned.py
+++ b/tests/test_runtime_c_unsigned.py
@@ -1,0 +1,28 @@
+import pathlib
+import subprocess
+import pytest
+
+RUNTIME_C_DIR = pathlib.Path(__file__).resolve().parent.parent / "runtime-c"
+HARNESS = pathlib.Path(__file__).resolve().parent / "runtime_c_unsigned_harness.c"
+
+def compile_and_run(macro: str, tmp_path):
+    runtime = RUNTIME_C_DIR / "safelang_runtime.c"
+    obj = tmp_path / "safelang_runtime.o"
+    exe = tmp_path / "test"
+    subprocess.check_call(["cc", "-std=c99", "-c", runtime, "-o", obj])
+    subprocess.check_call([
+        "cc",
+        "-std=c99",
+        HARNESS,
+        obj,
+        f"-D{macro}",
+        f"-I{RUNTIME_C_DIR}",
+        "-o",
+        exe,
+    ])
+    proc = subprocess.run([exe], capture_output=True)
+    assert proc.returncode < 0
+
+@pytest.mark.parametrize("macro", ["TEST_ADD", "TEST_SUB", "TEST_MUL", "TEST_DIV", "TEST_MOD"])
+def test_negative_operands_abort(macro, tmp_path):
+    compile_and_run(macro, tmp_path)


### PR DESCRIPTION
## Summary
- abort arithmetic operations when unsigned inputs are negative
- document unsigned negative operand behavior
- add C harness tests verifying abort on negative operands

## Testing
- `pytest tests/test_runtime_c_unsigned.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a354a22aa48328abd728e09add8893