### PR TITLE
Optimize parser newline handling and benchmark large sources

### DIFF
--- a/safelang/parser.py
+++ b/safelang/parser.py
@@ -1,6 +1,7 @@
 """Very minimal SafeLang parser for demonstration purposes."""
 
 import re
+from bisect import bisect_right
 from dataclasses import dataclass, field
 from typing import List
 
@@ -124,6 +125,8 @@ def parse_functions(text: str) -> List[FunctionDef]:
         offsets.append(pos)
         pos += len(ln) + 1
 
+    newline_positions = [idx for idx, ch in enumerate(sanitized) if ch == "\n"]
+
     i = 0
     while i < len(san_lines):
         line_san = san_lines[i].strip()
@@ -199,7 +202,7 @@ def parse_functions(text: str) -> List[FunctionDef]:
                 )
             )
 
-            i = sanitized.count("\n", 0, end_pos) + 1
+            i = bisect_right(newline_positions, end_pos) + 1
             continue
 
         i += 1

--- a/tests/test_parser_perf.py
+++ b/tests/test_parser_perf.py
@@ -1,0 +1,23 @@
+import time
+from safelang.parser import parse_functions
+
+
+def test_parse_large_source_performance():
+    """Parse a large synthetic source and ensure it finishes quickly."""
+    func_template = (
+        'function "f{0}" {{\n'
+        "  @space 1B\n"
+        "  @time 1ns\n"
+        "  consume {{}}\n"
+        "  emit {{}}\n"
+        "}}\n"
+    )
+    count = 1000
+    source = "@init\n" + "\n".join(func_template.format(i) for i in range(count))
+
+    start = time.perf_counter()
+    funcs = parse_functions(source)
+    duration = time.perf_counter() - start
+
+    assert len(funcs) == count
+    assert duration < 1.0, f"Parsing took too long: {duration:.3f}s"


### PR DESCRIPTION
## Summary
- precompute newline positions in `parse_functions` to avoid repeated counting
- add benchmark test covering large synthetic source parsing

## Testing
- `pre-commit run --files safelang/parser.py tests/test_parser_perf.py`
- `python -m pytest tests/test_parser_perf.py::test_parse_large_source_performance -q`


------
https://chatgpt.com/codex/tasks/task_e_68a354a0ba648328bb47b5b1adf3adf2