### PR TITLE
Validate contract entries in consume/emit blocks

### DIFF
--- a/safelang/parser.py
+++ b/safelang/parser.py
@@ -5,6 +5,8 @@ from bisect import bisect_right
 from dataclasses import dataclass, field
 from typing import List
 
+_PARAM_RE = re.compile(r"(\w+)\(([^)]+)\)")
+
 
 @dataclass
 class FunctionDef:
@@ -286,8 +288,26 @@ def verify_contracts(funcs: List[FunctionDef]) -> List[str]:
 
         if not fn.consume:
             errors.append(f"Function {fn.name} missing consume block")
+        else:
+            for entry in fn.consume:
+                stripped = entry.split("#", 1)[0].split("!", 1)[0].strip()
+                if stripped == "nil":
+                    continue
+                if not _PARAM_RE.fullmatch(stripped):
+                    errors.append(
+                        f"Function {fn.name} malformed consume entry: {entry.strip()}"
+                    )
         if not fn.emit:
             errors.append(f"Function {fn.name} missing emit block")
+        else:
+            for entry in fn.emit:
+                stripped = entry.split("#", 1)[0].split("!", 1)[0].strip()
+                if stripped == "nil":
+                    continue
+                if not _PARAM_RE.fullmatch(stripped):
+                    errors.append(
+                        f"Function {fn.name} malformed emit entry: {entry.strip()}"
+                    )
         if fn.lines > 128:
             errors.append(f"Function {fn.name} exceeds 128 line limit")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,7 +125,7 @@ def test_cli_emit_c_malformed(tmp_path):
         text=True,
     )
     assert result.returncode != 0
-    assert "ERROR" in result.stderr
+    assert "ERROR" in result.stdout
 
 
 def test_cli_emit_nasm(tmp_path):

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -148,3 +148,29 @@ def test_space_megabytes():
     src = 'function "mbytes" {\n@space 2MB\n@time 1ns\nconsume { nil }\nemit { nil }\n}'
     errors = _verify(src)
     assert errors == []
+
+
+def test_malformed_consume_entry():
+    src = (
+        'function "foo" {\n'
+        "@space 1B\n"
+        "@time 1ns\n"
+        "consume { int64 x }\n"
+        "emit { nil }\n"
+        "}"
+    )
+    errors = _verify(src)
+    assert "Function foo malformed consume entry: int64 x" in errors
+
+
+def test_malformed_emit_entry():
+    src = (
+        'function "foo" {\n'
+        "@space 1B\n"
+        "@time 1ns\n"
+        "consume { nil }\n"
+        "emit { int64 x }\n"
+        "}"
+    )
+    errors = _verify(src)
+    assert "Function foo malformed emit entry: int64 x" in errors


### PR DESCRIPTION
## Summary
- ensure consume and emit block lines match `type(name)` or `nil`
- add contract tests for malformed block entries
- adjust CLI test to expect contract validation errors on stdout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1eaebce8883288b8496758c6e35af