### PR TITLE
Filter annotations from generated code

### DIFF
--- a/safelang/compiler.py
+++ b/safelang/compiler.py
@@ -225,9 +225,8 @@ def generate_c(funcs: List[FunctionDef]) -> str:
             raise ValueError(f"{fn.name}: {exc}") from exc
         lines.append(f"/* {fn.name}: @space {fn.space} @time {fn.time} */")
         lines.append(f"void {fn.name}({', '.join(params)}) {{")
-        body = fn.body.strip().splitlines()
-        for b in body:
-            lines.append("    " + b.rstrip())
+        for b in _extract_body(fn.body):
+            lines.append(f"    {b}")
         lines.append("}")
 
         lines.append("")
@@ -244,9 +243,8 @@ def generate_rust(funcs: List[FunctionDef]) -> str:
             raise ValueError(f"{fn.name}: {exc}") from exc
         lines.append(f"// {fn.name}: @space {fn.space} @time {fn.time}")
         lines.append(f"pub fn {fn.name}({', '.join(params)}) {{")
-        body = fn.body.strip().splitlines()
-        for b in body:
-            lines.append("    " + b.rstrip())
+        for b in _extract_body(fn.body):
+            lines.append(f"    {b}")
         lines.append("}")
         lines.append("")
     return "\n".join(lines)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -44,6 +44,30 @@ def test_generate_rust_contains_clamp_params():
     assert "pub fn clamp_params" in rust_code
 
 
+def test_generate_c_omits_annotations():
+    funcs = _load_example_funcs()
+    c_code = generate_c(funcs)
+    for ln in c_code.splitlines():
+        stripped = ln.strip()
+        assert not (
+            stripped.startswith("@space")
+            or stripped.startswith("consume")
+            or stripped.startswith("emit")
+        )
+
+
+def test_generate_rust_omits_annotations():
+    funcs = _load_example_funcs()
+    rust_code = generate_rust(funcs)
+    for ln in rust_code.splitlines():
+        stripped = ln.strip()
+        assert not (
+            stripped.startswith("@space")
+            or stripped.startswith("consume")
+            or stripped.startswith("emit")
+        )
+
+
 def test_compile_to_nasm_simple_add():
     src = """
 function "add" {


### PR DESCRIPTION
## Summary
- Filter body using `_extract_body` when generating C and Rust
- Test that code generation omits `@space`, `consume`, and `emit`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1f58a322c8328a01f7111460cfe3b