### PR TITLE
Detect duplicate parameter names

### DIFF
--- a/safelang/compiler.py
+++ b/safelang/compiler.py
@@ -40,6 +40,7 @@ _PARAM_RE = re.compile(r"(\w+)\(([^)]+)\)")
 def _parse_params(lines: List[str], type_map: dict, style: str) -> List[str]:
     """Parse parameters from ``consume`` block lines."""
     params: List[str] = []
+    seen = set()
     for ln in lines:
         stripped = ln.split("#", 1)[0].split("!", 1)[0].strip()
         if stripped == "nil":
@@ -48,6 +49,8 @@ def _parse_params(lines: List[str], type_map: dict, style: str) -> List[str]:
         if not match:
             raise ValueError(f"Malformed parameter: {ln}")
         typ, name = match.group(1), match.group(2)
+        if name in seen:
+            raise ValueError(f"Duplicate parameter name: {name}")
         mapped = type_map.get(typ)
         if mapped is None:
             raise ValueError(f"Unknown type: {typ}")
@@ -55,6 +58,7 @@ def _parse_params(lines: List[str], type_map: dict, style: str) -> List[str]:
             params.append(f"{mapped} {name}")
         else:  # rust
             params.append(f"{name}: {mapped}")
+        seen.add(name)
     return params
 
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -3,7 +3,13 @@ from pathlib import Path
 import pytest
 
 from safelang import parse_functions, compile_to_nasm
-from safelang.compiler import _parse_space, _compile_expr
+from safelang.compiler import (
+    _parse_space,
+    _compile_expr,
+    _parse_params,
+    _C_TYPE_MAP,
+    _RUST_TYPE_MAP,
+)
 
 
 def test_compile_to_nasm(tmp_path):
@@ -46,3 +52,12 @@ def test_parse_space_invalid():
         _parse_space("10XB")
     with pytest.raises(ValueError):
         _parse_space("foo")
+
+
+@pytest.mark.parametrize(
+    "style,type_map", [("c", _C_TYPE_MAP), ("rust", _RUST_TYPE_MAP)]
+)
+def test_parse_params_duplicate_names(style, type_map):
+    lines = ["int32(x)", "int32(x)"]
+    with pytest.raises(ValueError):
+        _parse_params(lines, type_map, style)


### PR DESCRIPTION
## Summary
- ensure `_parse_params` raises on duplicate parameter names
- add tests covering duplicate parameter detection

## Testing
- `pre-commit run --files safelang/compiler.py tests/test_compiler.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1f58951ac8328a041a52cd154c255