### PR TITLE
Normalize contract units

### DIFF
--- a/safelang/parser.py
+++ b/safelang/parser.py
@@ -269,7 +269,7 @@ def verify_contracts(funcs: List[FunctionDef]) -> List[str]:
             init_count += 1
 
         _validate_numeric_attr(
-            fn.space,
+            fn.space.upper(),
             r"[0-9_]+[KMGT]?B",
             errors,
             f"Function {fn.name} missing @space",
@@ -278,7 +278,7 @@ def verify_contracts(funcs: List[FunctionDef]) -> List[str]:
         )
 
         _validate_numeric_attr(
-            fn.time,
+            fn.time.lower(),
             r"[0-9_]+ns",
             errors,
             f"Function {fn.name} missing @time",

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -150,6 +150,20 @@ def test_space_megabytes():
     assert errors == []
 
 
+def test_space_mixed_case_unit():
+    src = (
+        'function "mixspace" {\n@space 1kB\n@time 1ns\nconsume { nil }\nemit { nil }\n}'
+    )
+    errors = _verify(src)
+    assert errors == []
+
+
+def test_time_mixed_case_unit():
+    src = 'function "mixtime" {\n@space 1B\n@time 1NS\nconsume { nil }\nemit { nil }\n}'
+    errors = _verify(src)
+    assert errors == []
+
+
 def test_malformed_consume_entry():
     src = (
         'function "foo" {\n'


### PR DESCRIPTION
## Summary
- Normalize function @space values to uppercase and @time values to lowercase before validation
- Add tests ensuring mixed-case unit declarations are accepted

## Testing
- `pre-commit run --files safelang/parser.py tests/test_contracts.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1f588c2388328a0d3fa28501b99ff