### PR TITLE
Emit void parameter list for zero-arg C stubs

### DIFF
--- a/safelang/compiler.py
+++ b/safelang/compiler.py
@@ -227,8 +227,9 @@ def generate_c(funcs: List[FunctionDef]) -> str:
             params = _parse_params(fn.consume, _C_TYPE_MAP, "c")
         except ValueError as exc:
             raise ValueError(f"{fn.name}: {exc}") from exc
+        param_list = ", ".join(params) if params else "void"
         lines.append(f"/* {fn.name}: @space {fn.space} @time {fn.time} */")
-        lines.append(f"void {fn.name}({', '.join(params)}) {{")
+        lines.append(f"void {fn.name}({param_list}) {{")
         for b in _extract_body(fn.body):
             lines.append(f"    {b}")
         lines.append("}")

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -38,6 +38,24 @@ def test_generate_c_contains_clamp_params():
     assert "clamp_params" in c_code
 
 
+def test_generate_c_zero_params_emit_void():
+    src = """
+function "noop" {
+    @space 0B
+    @time 0ns
+
+    consume { nil }
+
+    emit { nil }
+
+    return
+}
+"""
+    funcs = parse_functions(src)
+    c_code = generate_c(funcs)
+    assert "void noop(void)" in c_code
+
+
 def test_generate_rust_contains_clamp_params():
     funcs = _load_example_funcs()
     rust_code = generate_rust(funcs)


### PR DESCRIPTION
## Summary
- ensure the C code generator emits `void` for empty parameter lists to produce valid C signatures
- add a regression test covering generation of zero-parameter functions

## Testing
- pytest tests/test_codegen.py

------
https://chatgpt.com/codex/tasks/task_e_68d83d41c44883289c3fb459fa5b1529