### PR TITLE
Fix parsing of contract blocks when braces appear in comments

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -127,3 +127,24 @@ def test_unterminated_string():
     src = 'function "foo" { msg = "unterminated }'
     with pytest.raises(ValueError, match="Unterminated string"):
         parse_functions(src)
+
+
+def test_contract_blocks_preserve_comments_with_braces():
+    src = (
+        'function "foo" {\n'
+        '    @space 1B\n'
+        '    @time 1ns\n'
+        '    consume {\n'
+        '        // comment with } inside\n'
+        '        input(i8)\n'
+        '    }\n'
+        '    emit {\n'
+        '        ! comment } still inside\n'
+        '        output(i8)\n'
+        '    }\n'
+        '}\n'
+    )
+    funcs = parse_functions(src)
+    assert len(funcs) == 1
+    assert funcs[0].consume == ['// comment with } inside', 'input(i8)']
+    assert funcs[0].emit == ['! comment } still inside', 'output(i8)']


### PR DESCRIPTION
## Summary
- update the SafeLang parser to locate consume/emit blocks using brace depth on sanitized source
- ensure braces that appear inside comments or strings do not truncate contract blocks
- add a parser regression test covering braces inside consume/emit comments

## Testing
- pytest tests/test_parser.py

------
https://chatgpt.com/codex/tasks/task_e_68d83d40bff88328a5409a8a5fb8fd75