### PR TITLE
Fix sl_bounds shifts and add 63-bit tests

### DIFF
--- a/runtime-c/safelang_runtime.c
+++ b/runtime-c/safelang_runtime.c
@@ -10,12 +10,14 @@ static void check_bits(int bits) {
 void sl_bounds(int bits, bool signed_arith, int64_t *min_out, int64_t *max_out) {
     check_bits(bits);
     if (signed_arith) {
-        int64_t max_val = ((int64_t)1 << (bits - 1)) - 1;
-        int64_t min_val = -((int64_t)1 << (bits - 1));
+        uint64_t magnitude = UINT64_C(1) << (bits - 1);
+        int64_t max_val = (int64_t)(magnitude - 1);
+        int64_t min_val = -(int64_t)magnitude;
         if (min_out) *min_out = min_val;
         if (max_out) *max_out = max_val;
     } else {
-        int64_t max_val = ((int64_t)1 << bits) - 1;
+        uint64_t magnitude = UINT64_C(1) << bits;
+        int64_t max_val = (int64_t)(magnitude - 1);
         int64_t min_val = 0;
         if (min_out) *min_out = min_val;
         if (max_out) *max_out = max_val;

--- a/tests/runtime_c_bounds_harness.c
+++ b/tests/runtime_c_bounds_harness.c
@@ -1,0 +1,24 @@
+#include "safelang_runtime.h"
+
+int main(void) {
+    int64_t min_val = 0;
+    int64_t max_val = 0;
+
+    sl_bounds(63, true, &min_val, &max_val);
+    if (min_val != -(int64_t)(UINT64_C(1) << 62)) {
+        return 1;
+    }
+    if (max_val != (int64_t)((UINT64_C(1) << 62) - 1)) {
+        return 1;
+    }
+
+    sl_bounds(63, false, &min_val, &max_val);
+    if (min_val != 0) {
+        return 1;
+    }
+    if (max_val != (int64_t)((UINT64_C(1) << 63) - 1)) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/tests/test_runtime_c_bounds.py
+++ b/tests/test_runtime_c_bounds.py
@@ -1,0 +1,28 @@
+import pathlib
+import subprocess
+
+
+RUNTIME_C_DIR = pathlib.Path(__file__).resolve().parent.parent / "runtime-c"
+HARNESS = pathlib.Path(__file__).resolve().parent / "runtime_c_bounds_harness.c"
+
+
+def test_sl_bounds_high_bitwidth(tmp_path):
+    runtime = RUNTIME_C_DIR / "safelang_runtime.c"
+    obj = tmp_path / "safelang_runtime.o"
+    exe = tmp_path / "test_bounds"
+
+    subprocess.check_call(["cc", "-std=c99", "-c", runtime, "-o", obj])
+    subprocess.check_call(
+        [
+            "cc",
+            "-std=c99",
+            HARNESS,
+            obj,
+            f"-I{RUNTIME_C_DIR}",
+            "-o",
+            exe,
+        ]
+    )
+
+    proc = subprocess.run([exe])
+    assert proc.returncode == 0


### PR DESCRIPTION
## Summary
- rewrite the shift operations in `sl_bounds` to use unsigned arithmetic before converting back to signed values, avoiding undefined behavior at 63 bits
- add a C harness and pytest covering `sl_bounds(63, ...)` for both signed and unsigned modes

## Testing
- `pytest tests/test_runtime_c_bounds.py`


------
https://chatgpt.com/codex/tasks/task_e_68d83d3f6a74832883d528faba863ca9