### PR TITLE
Fix register assignment when consume block includes nil

### DIFF
--- a/safelang/compiler.py
+++ b/safelang/compiler.py
@@ -199,13 +199,15 @@ def compile_to_nasm(funcs: List[FunctionDef]) -> str:
             lines.append(f"    sub rsp, {space}")
 
         var_regs = {}
-        for idx, ln in enumerate(fn.consume):
+        param_idx = 0
+        for ln in fn.consume:
             match = _PARAM_RE.search(ln)
             if not match:
                 continue
-            if idx >= len(_PARAM_REGS):
+            if param_idx >= len(_PARAM_REGS):
                 raise ValueError(f"{fn.name}: too many parameters")
-            var_regs[match.group(2)] = _PARAM_REGS[idx]
+            var_regs[match.group(2)] = _PARAM_REGS[param_idx]
+            param_idx += 1
 
         for stmt in _extract_body(fn.body):
             for ins in _compile_stmt(stmt, var_regs):

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -61,3 +61,26 @@ def test_parse_params_duplicate_names(style, type_map):
     lines = ["int32(x)", "int32(x)"]
     with pytest.raises(ValueError):
         _parse_params(lines, type_map, style)
+
+
+def test_compile_to_nasm_param_register_skips_nil():
+    funcs = parse_functions(
+        """
+@init
+function "nil_first" {
+    @space 0B
+    @time 1ns
+    consume {
+        nil
+        int32(x)
+    }
+    emit {
+        nil
+    }
+    return x;
+}
+"""
+    )
+    asm = compile_to_nasm(funcs)
+    nil_first_block = asm.split("nil_first:", 1)[1]
+    assert "mov rax, rdi" in nil_first_block


### PR DESCRIPTION
## Summary
- adjust NASM generation to advance parameter register indexing only when a consume entry parses successfully
- add a regression test covering consume blocks that list `nil` before a real parameter

## Testing
- pytest tests/test_compiler.py

------
https://chatgpt.com/codex/tasks/task_e_68d83d3da470832895fab4370b6a113a