### PR TITLE
Harden C runtime division/modulo against INT64_MIN/-1 overflow

### DIFF
--- a/runtime-c/safelang_runtime.c
+++ b/runtime-c/safelang_runtime.c
@@ -1,5 +1,6 @@
 #include "safelang_runtime.h"
 #include <stdlib.h> /* for abort */
+#include <limits.h>
 
 static void check_bits(int bits) {
     if (bits <= 0 || bits > 63) {
@@ -91,27 +92,38 @@ sl_result_t sl_sat_mul(int64_t a, int64_t b, int bits, bool signed_arith) {
 }
 
 sl_result_t sl_sat_div(int64_t a, int64_t b, int bits, bool signed_arith) {
+    int64_t min_v, max_v;
+    sl_bounds(bits, signed_arith, &min_v, &max_v);
     if (!signed_arith && (a < 0 || b < 0)) {
         abort();
     }
     if (b == 0) {
         abort();
     }
-    int64_t total = a / b;
-    int64_t min_v, max_v;
-    sl_bounds(bits, signed_arith, &min_v, &max_v);
-    return clamp_internal(total, min_v, max_v);
+    if (signed_arith && a == INT64_MIN && b == -1) {
+        return clamp_internal(INT64_MAX, min_v, max_v);
+    }
+    __int128 wide_a = (__int128)a;
+    __int128 wide_b = (__int128)b;
+    __int128 total = wide_a / wide_b;
+    return clamp_from_wide(total, min_v, max_v);
 }
 
 sl_result_t sl_sat_mod(int64_t a, int64_t b, int bits, bool signed_arith) {
+    int64_t min_v, max_v;
+    sl_bounds(bits, signed_arith, &min_v, &max_v);
     if (!signed_arith && (a < 0 || b < 0)) {
         abort();
     }
     if (b == 0) {
         abort();
     }
-    int64_t total = a % b;
-    int64_t min_v, max_v;
-    sl_bounds(bits, signed_arith, &min_v, &max_v);
-    return clamp_internal(total, min_v, max_v);
+    if (signed_arith && a == INT64_MIN && b == -1) {
+        return clamp_internal(0, min_v, max_v);
+    }
+    __int128 wide_a = (__int128)a;
+    __int128 wide_b = (__int128)b;
+    __int128 quotient = wide_a / wide_b;
+    __int128 total = wide_a - (quotient * wide_b);
+    return clamp_from_wide(total, min_v, max_v);
 }

--- a/tests/runtime_c_saturation_harness.c
+++ b/tests/runtime_c_saturation_harness.c
@@ -1,5 +1,6 @@
 #include "safelang_runtime.h"
 
+#include <limits.h>
 #include <stdint.h>
 
 int main(void) {
@@ -16,6 +17,19 @@ int main(void) {
     sl_result_t mul_res = sl_sat_mul(big, other, bits, false);
     if (mul_res.value != max63 || !mul_res.saturated) {
         return 2;
+    }
+
+    const int signed_bits = 8;
+    const int64_t signed_max = 127;
+
+    sl_result_t div_res = sl_sat_div(INT64_MIN, -1, signed_bits, true);
+    if (div_res.value != signed_max || !div_res.saturated) {
+        return 3;
+    }
+
+    sl_result_t mod_res = sl_sat_mod(INT64_MIN, -1, signed_bits, true);
+    if (mod_res.value != 0 || mod_res.saturated) {
+        return 4;
     }
 
     return 0;

--- a/tests/test_runtime_c_saturation.py
+++ b/tests/test_runtime_c_saturation.py
@@ -28,3 +28,8 @@ def compile_and_run(tmp_path):
 def test_unsigned_extreme_saturates(tmp_path):
     returncode = compile_and_run(tmp_path)
     assert returncode == 0
+
+
+def test_signed_int64_min_divmod_boundary(tmp_path):
+    returncode = compile_and_run(tmp_path)
+    assert returncode == 0


### PR DESCRIPTION
### Motivation
- Avoid undefined behavior from performing `int64_t` `/` or `%` on overflow-prone operands such as `INT64_MIN / -1` by making the C runtime deterministic and matching Python/JS semantics.
- Ensure truncation-toward-zero and remainder sign behavior is consistent across runtimes while preserving saturating/clamping behavior for declared bit widths.

### Description
- Validate bit width and obtain `min`/`max` bounds first by calling `sl_bounds` at the start of `sl_sat_div` and `sl_sat_mod` and include `<limits.h>` for `INT64_MIN`/`INT64_MAX` constants.
- Add explicit guard for the signed overflow case `a == INT64_MIN && b == -1` to return a deterministic saturated result instead of performing UB-prone native division.
- Replace direct `int64_t` division and modulo with widened `__int128` arithmetic (`wide_a / wide_b` and `wide_a - (quotient * wide_b)`) to compute truncating division and remainder safely, and route results through `clamp_from_wide`/`clamp_internal`.
- Add C harness checks for the `INT64_MIN / -1` and `INT64_MIN % -1` boundary cases and a focused pytest `test_signed_int64_min_divmod_boundary` that compiles and runs the harness.

### Testing
- Compiled the modified runtime and harness with `cc -std=c99` as exercised by the test harness and ran `pytest -q tests/test_runtime_c_saturation.py` which executed the harness; result: `2 passed`.
- The added C harness assertions were executed (covering saturated division and zero remainder at the int64 boundary) and the focused pytest case passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1864fe6608328a72f72da82e85068)