### PR TITLE
Match @space/@time against sanitized function bodies and add tests

### DIFF
--- a/safelang/parser.py
+++ b/safelang/parser.py
@@ -179,10 +179,13 @@ def parse_functions(text: str) -> List[FunctionDef]:
             body = text[next_open + 1 : end_pos]
             line_count = body.count("\n") + 1 if body else 0
 
-            space_match = re.search(r"@space\s+(\S+)", body)
-            time_match = re.search(r"@time\s+(\S+)", body)
-
             body_sanitized = sanitized[next_open + 1 : end_pos]
+
+            space_match = re.search(r"@space\s+(\S+)", body_sanitized)
+            time_match = re.search(r"@time\s+(\S+)", body_sanitized)
+
+            space_value = body[space_match.start(1) : space_match.end(1)] if space_match else ""
+            time_value = body[time_match.start(1) : time_match.end(1)] if time_match else ""
 
             def extract_contract(keyword: str) -> List[str]:
                 match = re.search(rf"\b{keyword}\b", body_sanitized)
@@ -222,8 +225,8 @@ def parse_functions(text: str) -> List[FunctionDef]:
             funcs.append(
                 FunctionDef(
                     name=name,
-                    space=space_match.group(1) if space_match else "",
-                    time=time_match.group(1) if time_match else "",
+                    space=space_value,
+                    time=time_value,
                     body=body,
                     consume=consume_entries,
                     emit=emit_entries,

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -126,6 +126,32 @@ def test_space_missing_unit():
     assert errors == ["Function foo invalid @space value"]
 
 
+def test_space_in_comment_does_not_count():
+    src = (
+        'function "foo" {\n'
+        "// @space 1B\n"
+        "@time 1ns\n"
+        "consume { nil }\n"
+        "emit { nil }\n"
+        "}"
+    )
+    errors = _verify(src)
+    assert errors == ["Function foo missing @space"]
+
+
+def test_time_in_string_does_not_count():
+    src = (
+        'function "foo" {\n'
+        '@space 1B\n'
+        'note = "@time 1ns"\n'
+        "consume { nil }\n"
+        "emit { nil }\n"
+        "}"
+    )
+    errors = _verify(src)
+    assert errors == ["Function foo missing @time"]
+
+
 def test_time_missing_unit():
     src = 'function "foo" {\n@space 1B\n@time 10\nconsume { nil }\nemit { nil }\n}'
     errors = _verify(src)


### PR DESCRIPTION
### Motivation
- The parser was detecting `@space` and `@time` annotations by running regexes against the raw function `body`, which allowed annotations appearing inside comments or string literals to be treated as real annotations.
- Annotations should only be recognized in code, so detection must use the sanitized function body that has comments and strings blanked out (`body_sanitized`).

### Description
- Updated `parse_functions` in `safelang/parser.py` to run the `@space` and `@time` regexes on `body_sanitized` instead of raw `body` by using `body_sanitized = sanitized[next_open + 1 : end_pos]` and `re.search` against it.
- Preserved the original lexeme extraction by slicing the original `body` using the match spans from the sanitized matches (compute `space_value` and `time_value` from `body` using `match.start(1)`/`match.end(1)` on the sanitized match).
- Kept contract extraction logic using `body_sanitized` for contract blocks (`consume`/`emit`).
- Added parser/verification tests in `tests/test_contracts.py`: `test_space_in_comment_does_not_count` and `test_time_in_string_does_not_count` to ensure annotations in comments/strings are ignored.

### Testing
- Ran `pytest -q tests/test_contracts.py tests/test_parser.py` and all tests passed. 
- Test run result: `41 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d18652430483289a89f213ace75ff8)