### PR TITLE
Validate consume/emit domain fragments in contract verification

### DIFF
--- a/safelang/parser.py
+++ b/safelang/parser.py
@@ -6,6 +6,19 @@ from dataclasses import dataclass, field
 from typing import List
 
 _PARAM_RE = re.compile(r"(\w+)\(([^)]+)\)")
+_DOMAIN_VALUE_RE = re.compile(
+    r"""
+    [+-]?(?:inf|pi|e)|
+    [+-]?(?:\d+(?:_\d+)*(?:\.\d+(?:_\d+)*)?|\.\d+(?:_\d+)*)|
+    [+-]?\d+(?:_\d+)*/\d+(?:_\d+)*|
+    [A-Za-z_]\w*
+    """,
+    re.VERBOSE,
+)
+_DOMAIN_RE = re.compile(
+    rf"^\s*([\[(])\s*({_DOMAIN_VALUE_RE.pattern})\s*,\s*({_DOMAIN_VALUE_RE.pattern})\s*([\])])\s*$",
+    re.VERBOSE,
+)
 
 
 @dataclass
@@ -309,23 +322,43 @@ def verify_contracts(funcs: List[FunctionDef]) -> List[str]:
             errors.append(f"Function {fn.name} missing consume block")
         else:
             for entry in fn.consume:
-                stripped = entry.split("#", 1)[0].split("!", 1)[0].strip()
-                if stripped == "nil":
+                signature, domain_expr = _split_contract_entry(entry)
+                if signature == "nil":
                     continue
-                if not _PARAM_RE.fullmatch(stripped):
+                if not _PARAM_RE.fullmatch(signature):
                     errors.append(
                         f"Function {fn.name} malformed consume entry: {entry.strip()}"
+                    )
+                    continue
+                if domain_expr is None:
+                    errors.append(
+                        f"Function {fn.name} consume entry missing domain: {entry.strip()}"
+                    )
+                    continue
+                if not _is_valid_domain_expr(domain_expr):
+                    errors.append(
+                        f"Function {fn.name} invalid consume domain in entry: {entry.strip()}"
                     )
         if not fn.emit:
             errors.append(f"Function {fn.name} missing emit block")
         else:
             for entry in fn.emit:
-                stripped = entry.split("#", 1)[0].split("!", 1)[0].strip()
-                if stripped == "nil":
+                signature, domain_expr = _split_contract_entry(entry)
+                if signature == "nil":
                     continue
-                if not _PARAM_RE.fullmatch(stripped):
+                if not _PARAM_RE.fullmatch(signature):
                     errors.append(
                         f"Function {fn.name} malformed emit entry: {entry.strip()}"
+                    )
+                    continue
+                if domain_expr is None:
+                    errors.append(
+                        f"Function {fn.name} emit entry missing domain: {entry.strip()}"
+                    )
+                    continue
+                if not _is_valid_domain_expr(domain_expr):
+                    errors.append(
+                        f"Function {fn.name} invalid emit domain in entry: {entry.strip()}"
                     )
         if fn.lines > 128:
             errors.append(f"Function {fn.name} exceeds 128 line limit")
@@ -336,6 +369,27 @@ def verify_contracts(funcs: List[FunctionDef]) -> List[str]:
         errors.append("Multiple @init functions defined")
 
     return errors
+
+
+def _split_contract_entry(entry: str) -> tuple[str, str | None]:
+    """Split a contract line into a signature and optional domain fragment."""
+
+    signature_fragment, domain_fragment = entry, None
+    if "#" in entry:
+        signature_fragment, domain_fragment = entry.split("#", 1)
+
+    signature = signature_fragment.split("!", 1)[0].strip()
+    if domain_fragment is None:
+        return signature, None
+
+    domain = domain_fragment.split("!", 1)[0].strip()
+    return signature, domain or None
+
+
+def _is_valid_domain_expr(domain_expr: str) -> bool:
+    """Validate SafeLang domain interval fragments."""
+
+    return bool(_DOMAIN_RE.fullmatch(domain_expr))
 
 
 __all__ = ["FunctionDef", "parse_functions", "verify_contracts"]

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -188,3 +188,79 @@ def test_malformed_emit_entry():
     )
     errors = _verify(src)
     assert "Function foo malformed emit entry: int64 x" in errors
+
+
+def test_consume_entry_missing_domain():
+    src = (
+        'function "foo" {\n'
+        "@space 1B\n"
+        "@time 1ns\n"
+        "consume { f32(x) }\n"
+        "emit { nil }\n"
+        "}"
+    )
+    errors = _verify(src)
+    assert "Function foo consume entry missing domain: f32(x)" in errors
+
+
+def test_emit_entry_missing_domain():
+    src = (
+        'function "foo" {\n'
+        "@space 1B\n"
+        "@time 1ns\n"
+        "consume { nil }\n"
+        "emit { f32(y) }\n"
+        "}"
+    )
+    errors = _verify(src)
+    assert "Function foo emit entry missing domain: f32(y)" in errors
+
+
+def test_invalid_consume_domain():
+    src = (
+        'function "foo" {\n'
+        "@space 1B\n"
+        "@time 1ns\n"
+        "consume {\n"
+        "  f32(x) # invalid\n"
+        "}\n"
+        "emit { nil }\n"
+        "}"
+    )
+    errors = _verify(src)
+    assert "Function foo invalid consume domain in entry: f32(x) # invalid" in errors
+
+
+def test_invalid_emit_domain():
+    src = (
+        'function "foo" {\n'
+        "@space 1B\n"
+        "@time 1ns\n"
+        "consume { nil }\n"
+        "emit {\n"
+        "  f32(y) # [0 1]\n"
+        "}\n"
+        "}"
+    )
+    errors = _verify(src)
+    assert "Function foo invalid emit domain in entry: f32(y) # [0 1]" in errors
+
+
+def test_valid_domain_forms():
+    src = (
+        'function "foo" {\n'
+        "@space 1B\n"
+        "@time 1ns\n"
+        "consume {\n"
+        "  f32(x) # [0, 3/2]\n"
+        "  f32(y) # [-3, 4.29382)\n"
+        "  f32(z) # [-inf, pi]\n"
+        "}\n"
+        "emit {\n"
+        "  f32(x) # [0, 1]\n"
+        "  f32(y) # (-1.5, e]\n"
+        "}\n"
+        "}"
+    )
+    errors = _verify(src)
+    assert errors == []


### PR DESCRIPTION
### Motivation
- Ensure every non-`nil` `consume`/`emit` contract line includes a domain fragment and that the fragment follows the interval-style syntax used in examples. 
- Provide precise, actionable error messages that include the function name and offending entry when domains are missing or malformed.

### Description
- Added domain parsing/validation regexes ` _DOMAIN_VALUE_RE` and `_DOMAIN_RE` to recognize numeric, fractional, symbolic (`pi`, `e`, `inf`) and identifier forms used inside interval brackets. 
- Introduced `_split_contract_entry` to split a contract line into a signature and optional `# ...` domain fragment, and `_is_valid_domain_expr` to validate domain fragments. 
- Extended `verify_contracts` so that for every non-`nil` `consume`/`emit` entry it validates the signature, requires a domain fragment, validates the domain format, and emits precise errors like `Function <name> consume entry missing domain: <entry>` or `Function <name> invalid consume domain in entry: <entry>` when appropriate. 
- Added tests in `tests/test_contracts.py` covering missing domains, invalid domain formats, and accepted valid interval forms matching `example.slang`.

### Testing
- Ran `pytest -q tests/test_contracts.py` and all tests passed: `27 passed`.
- The new tests verify missing/invalid domain error messages and acceptance of valid interval forms.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d186533ed0832896d61ddd47fcd6b6)