### PR TITLE
Honor emit contracts in C/Rust codegen signatures

### DIFF
--- a/safelang/compiler.py
+++ b/safelang/compiler.py
@@ -62,6 +62,28 @@ def _parse_params(lines: List[str], type_map: dict, style: str) -> List[str]:
     return params
 
 
+def _parse_typed_entries(lines: List[str], type_map: dict) -> List[tuple[str, str]]:
+    """Parse ``consume``/``emit`` entries into ``(mapped_type, name)`` tuples."""
+    entries: List[tuple[str, str]] = []
+    seen = set()
+    for ln in lines:
+        stripped = ln.split("#", 1)[0].split("!", 1)[0].strip()
+        if stripped == "nil":
+            continue
+        match = _PARAM_RE.fullmatch(stripped)
+        if not match:
+            raise ValueError(f"Malformed parameter: {ln}")
+        typ, name = match.group(1), match.group(2)
+        if name in seen:
+            raise ValueError(f"Duplicate parameter name: {name}")
+        mapped = type_map.get(typ)
+        if mapped is None:
+            raise ValueError(f"Unknown type: {typ}")
+        entries.append((mapped, name))
+        seen.add(name)
+    return entries
+
+
 def _parse_space(space: str) -> int:
     """Parse a memory size string into bytes.
 
@@ -227,13 +249,31 @@ def generate_c(funcs: List[FunctionDef]) -> str:
     for fn in funcs:
         try:
             params = _parse_params(fn.consume, _C_TYPE_MAP, "c")
+            emit_entries = _parse_typed_entries(fn.emit, _C_TYPE_MAP)
         except ValueError as exc:
             raise ValueError(f"{fn.name}: {exc}") from exc
         param_list = ", ".join(params) if params else "void"
+        return_type = "void"
+        if len(emit_entries) == 1:
+            return_type = emit_entries[0][0]
+        elif len(emit_entries) > 1:
+            struct_name = f"{fn.name}_emit_t"
+            lines.append(f"typedef struct {struct_name} {{")
+            for emit_type, emit_name in emit_entries:
+                lines.append(f"    {emit_type} {emit_name};")
+            lines.append(f"}} {struct_name};")
+            lines.append("")
+            return_type = struct_name
+
         lines.append(f"/* {fn.name}: @space {fn.space} @time {fn.time} */")
-        lines.append(f"void {fn.name}({param_list}) {{")
+        lines.append(f"{return_type} {fn.name}({param_list}) {{")
         for b in _extract_body(fn.body):
             lines.append(f"    {b}")
+        if len(emit_entries) == 1:
+            lines.append(f"    return {emit_entries[0][1]};")
+        elif len(emit_entries) > 1:
+            return_values = ", ".join(f".{name} = {name}" for _, name in emit_entries)
+            lines.append(f"    return ({return_type}){{{return_values}}};")
         lines.append("}")
 
         lines.append("")
@@ -246,12 +286,24 @@ def generate_rust(funcs: List[FunctionDef]) -> str:
     for fn in funcs:
         try:
             params = _parse_params(fn.consume, _RUST_TYPE_MAP, "rust")
+            emit_entries = _parse_typed_entries(fn.emit, _RUST_TYPE_MAP)
         except ValueError as exc:
             raise ValueError(f"{fn.name}: {exc}") from exc
+        return_sig = ""
+        if len(emit_entries) == 1:
+            return_sig = f" -> {emit_entries[0][0]}"
+        elif len(emit_entries) > 1:
+            tuple_types = ", ".join(emit_type for emit_type, _ in emit_entries)
+            return_sig = f" -> ({tuple_types})"
         lines.append(f"// {fn.name}: @space {fn.space} @time {fn.time}")
-        lines.append(f"pub fn {fn.name}({', '.join(params)}) {{")
+        lines.append(f"pub fn {fn.name}({', '.join(params)}){return_sig} {{")
         for b in _extract_body(fn.body):
             lines.append(f"    {b}")
+        if len(emit_entries) == 1:
+            lines.append(f"    {emit_entries[0][1]}")
+        elif len(emit_entries) > 1:
+            tuple_values = ", ".join(name for _, name in emit_entries)
+            lines.append(f"    ({tuple_values})")
         lines.append("}")
         lines.append("")
     return "\n".join(lines)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,6 +62,8 @@ def test_cli_emit_c():
     )
     assert result.returncode == 0
     assert "#include <stdint.h>" in result.stdout
+    assert "typedef struct clamp_params_emit_t {" in result.stdout
+    assert "clamp_params_emit_t clamp_params(float x, float y, float z)" in result.stdout
 
 
 def test_cli_emit_rust():
@@ -72,7 +74,7 @@ def test_cli_emit_rust():
         text=True,
     )
     assert result.returncode == 0
-    assert "pub fn clamp_params(" in result.stdout
+    assert "pub fn clamp_params(x: f32, y: f32, z: f32) -> (f32, f32, f32)" in result.stdout
 
 
 def test_cli_c_out(tmp_path):
@@ -86,6 +88,7 @@ def test_cli_c_out(tmp_path):
     assert result.returncode == 0
     assert result.stdout == ""
     assert "#include <stdint.h>" in out_file.read_text()
+    assert "typedef struct clamp_params_emit_t {" in out_file.read_text()
 
 
 def test_cli_rust_out(tmp_path):
@@ -98,7 +101,7 @@ def test_cli_rust_out(tmp_path):
     )
     assert result.returncode == 0
     assert result.stdout == ""
-    assert "pub fn clamp_params(" in out_file.read_text()
+    assert "pub fn clamp_params(x: f32, y: f32, z: f32) -> (f32, f32, f32)" in out_file.read_text()
 
 
 def test_cli_emit_c_malformed(tmp_path):

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -56,10 +56,85 @@ function "noop" {
     assert "void noop(void)" in c_code
 
 
+def test_generate_c_single_emit_typed_return():
+    src = """
+function "identity" {
+    @space 0B
+    @time 0ns
+
+    consume { int32(x) }
+
+    emit { int32(x) }
+}
+"""
+    funcs = parse_functions(src)
+    c_code = generate_c(funcs)
+    assert "int32_t identity(int32_t x)" in c_code
+    assert "return x;" in c_code
+
+
+def test_generate_c_multi_emit_struct_return():
+    src = """
+function "pair" {
+    @space 0B
+    @time 0ns
+
+    consume { nil }
+
+    emit {
+        int32(left)
+        int32(right)
+    }
+}
+"""
+    funcs = parse_functions(src)
+    c_code = generate_c(funcs)
+    assert "typedef struct pair_emit_t {" in c_code
+    assert "pair_emit_t pair(void)" in c_code
+    assert "return (pair_emit_t){.left = left, .right = right};" in c_code
+
+
 def test_generate_rust_contains_clamp_params():
     funcs = _load_example_funcs()
     rust_code = generate_rust(funcs)
     assert "pub fn clamp_params" in rust_code
+
+
+def test_generate_rust_single_emit_typed_return():
+    src = """
+function "identity" {
+    @space 0B
+    @time 0ns
+
+    consume { int32(x) }
+
+    emit { int32(x) }
+}
+"""
+    funcs = parse_functions(src)
+    rust_code = generate_rust(funcs)
+    assert "pub fn identity(x: i32) -> i32" in rust_code
+    assert "\n    x\n" in rust_code
+
+
+def test_generate_rust_multi_emit_tuple_return():
+    src = """
+function "pair" {
+    @space 0B
+    @time 0ns
+
+    consume { nil }
+
+    emit {
+        int32(left)
+        int32(right)
+    }
+}
+"""
+    funcs = parse_functions(src)
+    rust_code = generate_rust(funcs)
+    assert "pub fn pair() -> (i32, i32)" in rust_code
+    assert "\n    (left, right)\n" in rust_code
 
 
 def test_generate_c_omits_annotations():
@@ -146,6 +221,34 @@ def test_generate_c_unknown_type_raises():
 
 def test_generate_rust_unknown_type_raises():
     funcs = _load_bad_funcs()
+    with pytest.raises(ValueError, match="Unknown type: foo"):
+        generate_rust(funcs)
+
+
+def test_generate_c_unknown_emit_type_raises():
+    src = """
+function "bad_emit" {
+    @space 0B
+    @time 0ns
+    consume { nil }
+    emit { foo(x) }
+}
+"""
+    funcs = parse_functions(src)
+    with pytest.raises(ValueError, match="Unknown type: foo"):
+        generate_c(funcs)
+
+
+def test_generate_rust_unknown_emit_type_raises():
+    src = """
+function "bad_emit" {
+    @space 0B
+    @time 0ns
+    consume { nil }
+    emit { foo(x) }
+}
+"""
+    funcs = parse_functions(src)
     with pytest.raises(ValueError, match="Unknown type: foo"):
         generate_rust(funcs)
 


### PR DESCRIPTION
### Motivation
- The code generator previously ignored `emit` contracts when producing C/Rust signatures and bodies, causing mismatch between declared emits and generated APIs. 
- Emit entries must influence return types so backends produce accurate, typed outputs for single and multi-value emits.

### Description
- Added a `_parse_typed_entries` helper to parse and validate `emit` (and re-usable for `consume`) entries against type maps and detect malformed or unknown types in `safelang/compiler.py`.
- Updated `generate_c` to select a return type based on `emit` cardinality, emit a `typedef struct <fn>_emit_t` for multiple emits, and insert explicit `return` statements for scalar and struct returns.
- Updated `generate_rust` to produce a Rust return signature for single emits and tuple types for multi-emits, and to emit corresponding return expressions in the function body.
- Expanded tests in `tests/test_codegen.py` and `tests/test_cli.py` to cover single and multi-value emits, verify emitted typedef/tuple signatures, and assert proper errors for unknown/malformed emit types.

### Testing
- Ran the full test suite with `pytest -q` and all automated tests passed: `136 passed`.
- New and existing codegen and CLI tests exercise C and Rust signature generation, multi-value struct/tuple returns, and emit-type error handling, and they succeeded under CI-local run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d186565e848328ac16ccd634fb7c37)