### PR TITLE
Raise explicit NASM codegen errors for unsupported syntax

### DIFF
--- a/safelang/__main__.py
+++ b/safelang/__main__.py
@@ -44,14 +44,14 @@ def main() -> int:
             print(f"ERROR: {e}")
         return 1
 
-    if args.nasm:
-        asm = compile_to_nasm(funcs)
-        try:
-            args.nasm.write_text(asm)
-        except OSError as exc:
-            print(f"ERROR: {exc}", file=sys.stderr)
-            return 1
     try:
+        if args.nasm:
+            asm = compile_to_nasm(funcs)
+            try:
+                args.nasm.write_text(asm)
+            except OSError as exc:
+                print(f"ERROR: {exc}", file=sys.stderr)
+                return 1
         if args.emit_c or args.c_out:
             code = generate_c(funcs)
             if args.c_out:

--- a/safelang/compiler.py
+++ b/safelang/compiler.py
@@ -120,7 +120,7 @@ def _tokenize(expr: str) -> List[str]:
     return _TOKEN_RE.findall(expr)
 
 
-def _compile_expr(expr: str, var_regs: dict) -> List[str]:
+def _compile_expr(expr: str, var_regs: dict, fn_name: str, stmt: str) -> List[str]:
     tokens = _tokenize(expr)
     if not tokens:
         return []
@@ -143,17 +143,19 @@ def _compile_expr(expr: str, var_regs: dict) -> List[str]:
             code.append("cqo")
             code.append(f"idiv {rhs_val}")
         else:
-            code.append(f"; unsupported op {op}")
+            raise ValueError(
+                f"{fn_name}: unsupported operator {op!r} in statement {stmt!r}"
+            )
         return code
-    return [f"; unsupported expr {expr}"]
+    raise ValueError(f"{fn_name}: unsupported expression {expr!r} in statement {stmt!r}")
 
 
-def _compile_stmt(stmt: str, var_regs: dict) -> List[str]:
-    stmt = stmt.strip().rstrip(";")
-    if stmt.startswith("return"):
-        expr = stmt[len("return") :].strip()
-        return _compile_expr(expr, var_regs)
-    return [f"; unsupported: {stmt}"]
+def _compile_stmt(stmt: str, var_regs: dict, fn_name: str) -> List[str]:
+    normalized_stmt = stmt.strip().rstrip(";")
+    if normalized_stmt.startswith("return"):
+        expr = normalized_stmt[len("return") :].strip()
+        return _compile_expr(expr, var_regs, fn_name, normalized_stmt)
+    raise ValueError(f"{fn_name}: unsupported statement {normalized_stmt!r}")
 
 
 def _extract_body(body: str) -> List[str]:
@@ -210,7 +212,7 @@ def compile_to_nasm(funcs: List[FunctionDef]) -> str:
             param_idx += 1
 
         for stmt in _extract_body(fn.body):
-            for ins in _compile_stmt(stmt, var_regs):
+            for ins in _compile_stmt(stmt, var_regs, fn.name):
                 lines.append(f"    {ins}")
 
         if space:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,13 +129,66 @@ def test_cli_emit_c_malformed(tmp_path):
 
 
 def test_cli_emit_nasm(tmp_path):
-    src = Path(__file__).resolve().parents[1] / "example.slang"
+    src = (
+        "@init\n"
+        'function "init" {\n'
+        "    @space 1B\n"
+        "    @time 1ns\n"
+        "    consume { nil }\n"
+        "    emit { nil }\n"
+        "    return 0\n"
+        "}\n"
+        'function "add" {\n'
+        "    @space 1B\n"
+        "    @time 1ns\n"
+        "    consume {\n"
+        "        int64(a)\n"
+        "        int64(b)\n"
+        "    }\n"
+        "    emit { int64(r) }\n"
+        "    return a + b\n"
+        "}\n"
+    )
+    src_file = tmp_path / "ok.slang"
+    src_file.write_text(src)
     out_file = tmp_path / "out.asm"
     result = subprocess.run(
-        [sys.executable, "-m", "safelang", "--nasm", str(out_file), str(src)]
+        [sys.executable, "-m", "safelang", "--nasm", str(out_file), str(src_file)]
     )
     assert result.returncode == 0
     assert out_file.read_text().startswith("; Auto-generated NASM")
+
+
+def test_cli_emit_nasm_unsupported_input(tmp_path):
+    src = (
+        "@init\n"
+        'function "init" {\n'
+        "    @space 1B\n"
+        "    @time 1ns\n"
+        "    consume { nil }\n"
+        "    emit { nil }\n"
+        "    return 0\n"
+        "}\n"
+        'function "badnasm" {\n'
+        "    @space 1B\n"
+        "    @time 1ns\n"
+        "    consume { int64(a) }\n"
+        "    emit { int64(r) }\n"
+        "    a = a + 1\n"
+        "}\n"
+    )
+    src_file = tmp_path / "badnasm.slang"
+    out_file = tmp_path / "out.asm"
+    src_file.write_text(src)
+    result = subprocess.run(
+        [sys.executable, "-m", "safelang", "--nasm", str(out_file), str(src_file)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "ERROR:" in result.stderr
+    assert "badnasm: unsupported statement" in result.stderr
+    assert not out_file.exists()
 
 
 def test_cli_emit_conflict():

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -138,6 +138,43 @@ function "many" {
         compile_to_nasm(funcs)
 
 
+def test_compile_to_nasm_unsupported_statement_raises():
+    src = """
+function "oops" {
+    @space 0B
+    @time 0ns
+
+    consume { int64(a) }
+    emit { int64(r) }
+
+    a = a + 1
+}
+"""
+    funcs = parse_functions(src)
+    with pytest.raises(ValueError, match=r"oops: unsupported statement 'a = a \+ 1'"):
+        compile_to_nasm(funcs)
+
+
+def test_compile_to_nasm_unsupported_expr_raises():
+    src = """
+function "oops_expr" {
+    @space 0B
+    @time 0ns
+
+    consume { int64(a) }
+    emit { int64(r) }
+
+    return a + b + c
+}
+"""
+    funcs = parse_functions(src)
+    with pytest.raises(
+        ValueError,
+        match=r"oops_expr: unsupported expression 'a \+ b \+ c' in statement 'return a \+ b \+ c'",
+    ):
+        compile_to_nasm(funcs)
+
+
 def test_generate_c_unknown_type_raises():
     funcs = _load_bad_funcs()
     with pytest.raises(ValueError, match="Unknown type: foo"):


### PR DESCRIPTION
### Motivation

- Avoid silently emitting placeholder comments in NASM output for unsupported syntax and instead fail loudly so callers (and the CLI) can react to real codegen errors.
- Provide useful context in errors by including the function name and the original statement text to aid debugging.

### Description

- Replace fallback comment returns in NASM codegen with `ValueError` exceptions in `_compile_expr` and `_compile_stmt` and include function name and statement text in the messages.  (`safelang/compiler.py`) 
- Propagate function name into expression compilation by updating `_compile_expr` signature and call sites so errors are contextualized. (`safelang/compiler.py`) 
- Wrap `--nasm` generation inside the existing `try/except ValueError` block in the CLI so codegen failures print `ERROR:` to stderr and return a non-zero exit code. (`safelang/__main__.py`) 
- Add tests to validate new behavior: `tests/test_codegen.py` gains tests asserting unsupported statements and multi-operand expressions raise `ValueError` with contextual messages, and `tests/test_cli.py` gains a test asserting the CLI reports `ERROR:` and exits non-zero when `--nasm` input contains unsupported syntax.

### Testing

- Ran `pytest -q tests/test_codegen.py tests/test_cli.py` and all tests passed (`25 passed`).
- New tests added: `test_compile_to_nasm_unsupported_statement_raises`, `test_compile_to_nasm_unsupported_expr_raises`, and `test_cli_emit_nasm_unsupported_input`; they succeeded as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1865952cc8328890e61558d5955b1)