### PR TITLE
ci: fix coverage-badge on Python 3.14 and clear Node 20 deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pre-commit coverage coverage-badge
+          pip install pytest pre-commit coverage coverage-badge setuptools
       - name: Run pre-commit
         run: |
           pre-commit run --files $(git ls-files '*.py') || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,4 +24,5 @@ repos:
           - coverage
           - pytest
           - coverage-badge
+          - setuptools
         pass_filenames: false


### PR DESCRIPTION
## Summary

These two CI fixes were authored alongside PR #87 but landed on the branch *after* #87 was merged, so they never reached `main`. As a result `main`'s CI still fails. This PR carries them over.

## Changes

- **Install `setuptools` so `coverage-badge` works.** CI resolves `python-version: '3.x'` to Python 3.14, which no longer bundles `setuptools` via `ensurepip` (changed in 3.12). `coverage-badge` imports `pkg_resources` (provided by `setuptools`) at startup, so the "Generate coverage badge" step crashed with `ModuleNotFoundError: No module named 'pkg_resources'` even though all 147 tests passed. Added `setuptools` to the workflow's `pip install` and to the pre-commit local coverage hook's `additional_dependencies`.
- **Bump actions to Node 24-native majors.** `actions/checkout@v3` and `actions/setup-python@v4` target the deprecated Node.js 20 runtime and were being force-run on Node 24 with a deprecation warning. Bumped to `actions/checkout@v5` and `actions/setup-python@v6`, the first majors that natively target Node 24.

## Verification

- All 147 tests pass locally; `black --check` (pinned 24.4.2) and `pylint -E` are clean; coverage at 98%.
- The `pkg_resources` failure is in the badge step only and is resolved by installing `setuptools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ztGMYiGZj4Ak4TJ7KCWr2)_