### PR TITLE
ci: pin setuptools&lt;81 so coverage-badge can import pkg_resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pre-commit coverage coverage-badge setuptools
+          # coverage-badge imports pkg_resources, which setuptools>=81 removed.
+          # Pin setuptools<81 so it stays importable (Python 3.12+ has no setuptools by default).
+          pip install pytest pre-commit coverage coverage-badge 'setuptools<81'
       - name: Run pre-commit
         run: |
           pre-commit run --files $(git ls-files '*.py') || true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,5 +24,5 @@ repos:
           - coverage
           - pytest
           - coverage-badge
-          - setuptools
+          - setuptools<81
         pass_filenames: false


### PR DESCRIPTION
## Summary

Final piece of the CI fix. PRs #87 and #88 both auto-merged within ~35 seconds of creation, before follow-up fixes could be pushed, so the verified fix kept getting stranded on the branch. This PR carries it over — and the fix is already at the branch HEAD, so it lands even if this PR merges immediately.

## The actual root cause

The earlier "install `setuptools`" fix was **not sufficient**: the runner resolves plain `setuptools` to **82.x**, which has *removed* the `pkg_resources` module that `coverage-badge` imports at startup. So `main` still fails with `ModuleNotFoundError: No module named 'pkg_resources'`.

Verified empirically on Python 3.14:
- `setuptools 82.0.1` → `import pkg_resources` raises `ModuleNotFoundError` (reproduces CI failure exactly).
- `setuptools<81` (80.10.2) → `pkg_resources` imports and the exact `coverage-badge -o coverage.svg -f` command exits 0 and writes the badge.

This matches setuptools' own deprecation guidance, which tells consumers still relying on `pkg_resources` to "pin to Setuptools<81".

## Change

Pin `setuptools<81` in both the workflow's `pip install` step and the pre-commit coverage hook's `additional_dependencies`, with a comment explaining why so the pin isn't removed later.

## Verification

- Reproduced the failure and confirmed the fix on real Python 3.14 (not just locally on 3.11).
- All 147 tests pass; `black --check` (pinned 24.4.2) and `pylint -E` clean; coverage 98%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ztGMYiGZj4Ak4TJ7KCWr2)_